### PR TITLE
[Feat] MSA 모듈(Analysis/Socket/Report) 초기 환경 및 인프라 연동 세팅

### DIFF
--- a/analysis-service/build.gradle.kts
+++ b/analysis-service/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 	implementation("org.springframework.boot:spring-boot-starter-kafka")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.5")
 	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/config/KafkaConfig.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/config/KafkaConfig.kt
@@ -1,0 +1,11 @@
+package com.parkit.analysis.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+
+@EnableKafka
+@Configuration
+class KafkaConfig {
+    // Spring Boot 자동 구성(AutoConfiguration)이 application.yml 설정을 바탕으로 
+    // KafkaTemplate 및 ConcurrentKafkaListenerContainerFactory 등을 주입합니다.
+}

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/config/RedisConfig.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/config/RedisConfig.kt
@@ -1,0 +1,22 @@
+package com.parkit.analysis.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+
+    @Bean
+    fun reactiveRedisTemplate(factory: ReactiveRedisConnectionFactory): ReactiveRedisTemplate<String, String> {
+        val stringSerializer = StringRedisSerializer()
+        val context = RedisSerializationContext.newSerializationContext<String, String>(stringSerializer)
+            .hashKey(stringSerializer)
+            .hashValue(stringSerializer)
+            .build()
+        return ReactiveRedisTemplate(factory, context)
+    }
+}

--- a/analysis-service/src/main/resources/application.yml
+++ b/analysis-service/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: analysis-service
+  
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: analysis-group
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+logging:
+  level:
+    root: INFO
+    com.parkit.analysis: DEBUG
+    org.springframework.data.redis: INFO
+    org.springframework.kafka: INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: parkit-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: parkit_user
+      POSTGRES_PASSWORD: parkit_password
+      POSTGRES_DB: parkit_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  redis:
+    image: redis:7
+    container_name: parkit-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: parkit

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: parkit
+spec:
+  ports:
+  - port: 5432
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: parkit
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_USER
+          value: "parkit_user"
+        - name: POSTGRES_PASSWORD
+          value: "parkit_password"
+        - name: POSTGRES_DB
+          value: "parkit_db"
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5Gi

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: parkit
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: parkit
+spec:
+  serviceName: "redis"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 2Gi

--- a/report-service/build.gradle.kts
+++ b/report-service/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-kafka")
 	implementation("org.springframework.boot:spring-boot-starter-webmvc")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("tools.jackson.module:jackson-module-kotlin")
 	runtimeOnly("org.postgresql:postgresql")

--- a/report-service/src/main/kotlin/com/parkit/report/domain/CoachingReport.kt
+++ b/report-service/src/main/kotlin/com/parkit/report/domain/CoachingReport.kt
@@ -1,0 +1,26 @@
+package com.parkit.report.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "coaching_reports")
+class CoachingReport(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    val sessionId: String,
+
+    @Column(nullable = false)
+    val score: Int,
+
+    @Column(nullable = false, length = 1000)
+    val issues: String,
+
+    @Column(nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+) {
+    // 빈 생성자 및 클래스 속성은 Kotlin JPA plugin (allOpen, noArg) 등에 의해 처리됩니다.
+}

--- a/report-service/src/main/resources/application.yml
+++ b/report-service/src/main/resources/application.yml
@@ -1,0 +1,35 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: report-service
+  
+  datasource:
+    url: jdbc:postgresql://localhost:5432/parkit_db
+    username: parkit_user
+    password: parkit_password
+    driver-class-name: org.postgresql.Driver
+  
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: report-group
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+logging:
+  level:
+    root: INFO
+    com.parkit.report: DEBUG
+    org.springframework.kafka: INFO

--- a/socket-service/build.gradle.kts
+++ b/socket-service/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-kafka")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-websocket")
+	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.5")
 	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")

--- a/socket-service/src/main/kotlin/com/parkit/socket/config/WebSocketConfig.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/config/WebSocketConfig.kt
@@ -1,0 +1,29 @@
+package com.parkit.socket.config
+
+import com.parkit.socket.handler.CoachingSocketHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.HandlerMapping
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping
+import org.springframework.web.reactive.socket.WebSocketHandler
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter
+
+@Configuration
+class WebSocketConfig(
+    private val coachingSocketHandler: CoachingSocketHandler
+) {
+
+    @Bean
+    fun webSocketMapping(): HandlerMapping {
+        val map = mapOf<String, WebSocketHandler>("/ws/coaching" to coachingSocketHandler)
+        val mapping = SimpleUrlHandlerMapping()
+        mapping.order = 1
+        mapping.urlMap = map
+        return mapping
+    }
+
+    @Bean
+    fun handlerAdapter(): WebSocketHandlerAdapter {
+        return WebSocketHandlerAdapter()
+    }
+}

--- a/socket-service/src/main/kotlin/com/parkit/socket/handler/CoachingSocketHandler.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/handler/CoachingSocketHandler.kt
@@ -1,0 +1,21 @@
+package com.parkit.socket.handler
+
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.socket.WebSocketHandler
+import org.springframework.web.reactive.socket.WebSocketSession
+import reactor.core.publisher.Mono
+
+@Component
+class CoachingSocketHandler : WebSocketHandler {
+
+    override fun handle(session: WebSocketSession): Mono<Void> {
+        println("새로운 웹소켓 연결 수립: \${session.id}")
+        
+        // TODO: Kafka Consumer 연동 시, 해당 Flux를 구독하여 클라이언트로 데이터를 전송하는 로직 구성 (session.send)
+        val input = session.receive()
+            .doOnNext { message -> println("수신된 메시지: \${message.payloadAsText}") }
+            .then()
+            
+        return input
+    }
+}

--- a/socket-service/src/main/resources/application.yml
+++ b/socket-service/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: socket-service
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: socket-group
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+logging:
+  level:
+    root: INFO
+    com.parkit.socket: DEBUG
+    org.springframework.kafka: INFO


### PR DESCRIPTION
## 📝 변경 내용
- `analysis-service`, `socket-service`, `report-service` 3개의 마이크로서비스에 대한 필수 의존성을 추가하고 초기 설정(`application.yml`)을 완료했습니다.
- K8s 배포 및 로컬 테스트를 위한 DB(PostgreSQL), Redis 도커 컴포즈/K8s Manifest를 구성했습니다.

## 🛠️ 상세 내역 (Changes)

### 1. 인프라 설정 (DevOps 공통)
-  **로컬 개발용**: `docker-compose.yml` (PostgreSQL 15, Redis 7) 작성 완료
-  **K8s 배포용**: `k8s/namespace.yaml`, `k8s/postgres.yaml`, `k8s/redis.yaml` (StatefulSet 및 PVC 포함) 작성 완료
-  **서버 명세화**: 3개 서비스 공통 `springdoc-openapi` (Swagger UI) 의존성 추가 (http://localhost:808x/swagger-ui.html 접속 가능)
  - 분석 서버: http://localhost:8081/swagger-ui.html
  - 소켓 서버: http://localhost:8082/swagger-ui.html
  - 리포트 서버: http://localhost:8083/swagger-ui.html


### 2. Analysis Service (WebFlux + Kotlin + Redis + Kafka)
- `application.yml` 작성: 포트(`8081`), 내장 Redis(`6379`), Kafka 브로커(`9092`) 연결 설정
- `KafkaConfig.kt` 작성: 빈 자동 주입을 위한 `@EnableKafka` 활성화
- `RedisConfig.kt` 작성: 비동기 처리를 위한 `ReactiveRedisTemplate<String, String>` 빈 등록 완료

### 3. Socket Service (WebFlux + Kotlin + WebSocket)
- `application.yml` 작성: 포트(`8082`), Kafka (`coaching-events` 컨슘용) 접속 정보 정의
- `WebSocketConfig.kt` 작성: `/ws/coaching` 웹소켓 채널 라우팅 및 `WebSocketHandlerAdapter` 등록
- `CoachingSocketHandler.kt` 작성: 클라이언트 메시지 수신(Receive) 기본 골격 구현

### 4. Report Service (WebMVC + Kotlin + Postgres + JPA)
- `application.yml` 작성: 포트(`8083`), PostgreSQL 접속 정보 및 Hibernate(DDL-Update) 설정 적용
- `CoachingReport.kt` 작성: 주차 세션별 결과(Score, Issues)를 영구 저장하기 위한 JPA Entity 작성


## ✅ 체크리스트
- [x] 빌드 및 테스트를 통과했나요?
  - [x] 3개 모듈 모두 의존성 충돌 없이 `./gradlew build` 정상 통과 확인 완료.
  - [x] Docker Compose를 통한 Postgres/Redis 로컬 정상 부팅 확인 완료.
- [x] 불필요한 로그나 주석은 제거했나요?
- [x] 코드 컨벤션을 준수했나요?

## 🚨 리뷰 포인트
- 각 서비스의 `Kafka`는 로컬 설정(`localhost:9092`)을 바라보고 있습니다. 1번 팀(플랫폼)의 실 서버 배포 주소가 나오면 운영용 `application-prod.yml` 등으로 분리해야 합니다.
- API 문서화(Swagger)를 위한 라이브러리가 각 서비스 `build.gradle.kts`에 추가되었습니다. 리뷰 시 빌드 성공 여부를 확인해 주세요.