### PR TITLE
[Feat] MSA 서비스 각각에 Swagger 설정 추가

### DIFF
--- a/analysis-service/src/main/kotlin/com/parkit/analysis/config/SwaggerConfig.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/config/SwaggerConfig.kt
@@ -1,0 +1,21 @@
+package com.parkit.analysis.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Parkit Analysis Service API")
+                    .description("API Documentation for Analysis Service")
+                    .version("1.0.0")
+            )
+    }
+}

--- a/analysis-service/src/main/resources/application.yml
+++ b/analysis-service/src/main/resources/application.yml
@@ -27,3 +27,9 @@ logging:
     com.parkit.analysis: DEBUG
     org.springframework.data.redis: INFO
     org.springframework.kafka: INFO
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,16 @@
+## 📌 관련 이슈
+- #이슈번호
+
+## ✨ 변경 내용
+- `report-service` OpenAPI(Swagger) 설정 추가 (`SwaggerConfig.kt`, `application.yml`)
+- `analysis-service` OpenAPI(Swagger) 설정 추가 (`SwaggerConfig.kt`, `application.yml`)
+- `socket-service` OpenAPI(Swagger) 설정 추가 (`SwaggerConfig.kt`, `application.yml`)
+- 각 마이크로서비스에서 개별적으로 API 문서를 확인할 수 있도록 `/swagger-ui.html` 및 `/v3/api-docs` 엔드포인트 활성화
+
+## ✅ 체크리스트
+- [x] 빌드 및 테스트를 통과했나요?
+- [x] 불필요한 로그나 주석은 제거했나요?
+
+## 📝 리뷰 포인트
+- 각 서비스의 OpenAPI Info(Title, Version, Description)가 적명한지 확인 부탁드립니다.
+- 추후 전체 서비스를 묶어주는 API Gateway 통합 시 해당 개별 Swagger 문서들을 하나로 통합할 기반이 확보되었습니다.

--- a/report-service/src/main/kotlin/com/parkit/report/config/SwaggerConfig.kt
+++ b/report-service/src/main/kotlin/com/parkit/report/config/SwaggerConfig.kt
@@ -1,0 +1,21 @@
+package com.parkit.report.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Parkit Report Service API")
+                    .description("API Documentation for Report Service")
+                    .version("1.0.0")
+            )
+    }
+}

--- a/report-service/src/main/resources/application.yml
+++ b/report-service/src/main/resources/application.yml
@@ -33,3 +33,9 @@ logging:
     root: INFO
     com.parkit.report: DEBUG
     org.springframework.kafka: INFO
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs

--- a/socket-service/src/main/kotlin/com/parkit/socket/config/SwaggerConfig.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/config/SwaggerConfig.kt
@@ -1,0 +1,21 @@
+package com.parkit.socket.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("Parkit Socket Service API")
+                    .description("API Documentation for Socket Service")
+                    .version("1.0.0")
+            )
+    }
+}

--- a/socket-service/src/main/resources/application.yml
+++ b/socket-service/src/main/resources/application.yml
@@ -18,3 +18,9 @@ logging:
     root: INFO
     com.parkit.socket: DEBUG
     org.springframework.kafka: INFO
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs


### PR DESCRIPTION
## 📌 관련 이슈
- X

## ✨ 변경 내용
- `report-service` OpenAPI(Swagger) 설정 추가 (`SwaggerConfig.kt`, `application.yml`)
- `analysis-service` OpenAPI(Swagger) 설정 추가 (`SwaggerConfig.kt`, `application.yml`)
- `socket-service` OpenAPI(Swagger) 설정 추가 (`SwaggerConfig.kt`, `application.yml`)
- 각 마이크로서비스에서 개별적으로 API 문서를 확인할 수 있도록 `/swagger-ui.html` 및 `/v3/api-docs` 엔드포인트 활성화

## ✅ 체크리스트
- [x] 빌드 및 테스트를 통과했나요?
- [x] 불필요한 로그나 주석은 제거했나요?

## 📝 리뷰 포인트
- 각 서비스의 OpenAPI Info(Title, Version, Description)가 적명한지 확인 부탁드립니다.
- 추후 전체 서비스를 묶어주는 API Gateway 통합 시 해당 개별 Swagger 문서들을 하나로 통합할 기반이 확보되었습니다.
