### PR TITLE
socket-service CrashLoopBackOff 방지 (Kafka 옵션화)

### DIFF
--- a/socket-service/src/main/kotlin/com/parkit/socket/kafka/CoachingEventConsumer.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/kafka/CoachingEventConsumer.kt
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.parkit.socket.dto.CoachingSocketDto
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Component
 
 @Component
+@ConditionalOnProperty(prefix = "parkit.kafka", name = ["enabled"], havingValue = "true")
 class CoachingEventConsumer(
 	private val messagingTemplate: SimpMessagingTemplate,
 	private val objectMapper: ObjectMapper,

--- a/socket-service/src/main/resources/application.yml
+++ b/socket-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: socket-service
 
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: ${PARKIT_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
       group-id: socket-group
       auto-offset-reset: latest
@@ -15,6 +15,7 @@ spring:
 
 parkit:
   kafka:
+    enabled: false
     topics:
       coachingEvent: coaching-event
 


### PR DESCRIPTION
## 문제
- socket-service가 Kafka bootstrap.servers 설정 문제로 기동 시점에 CrashLoopBackOff 발생
- WebSocket/Swagger까지 함께 내려가면서 외부 접속 불가

## 해결
- Kafka consumer(CoachingEventConsumer)를 `parkit.kafka.enabled=true`일 때만 등록하도록 변경
- `spring.kafka.bootstrap-servers`를 `PARKIT_KAFKA_BOOTSTRAP_SERVERS`로 오버라이드 가능하게 설정
- 기본값은 `parkit.kafka.enabled=false`로 두어 Kafka 미구성 환경에서도 서비스가 정상 기동

## 운영 사용법
- Kafka를 사용하려면 아래 설정을 적용
  - `parkit.kafka.enabled: true`
  - `PARKIT_KAFKA_BOOTSTRAP_SERVERS=<kafka-bootstrap:9092>`

## 영향
- Kafka가 비활성화된 상태에서는 coaching-event 구독/브로드캐스트가 동작하지 않습니다. (WebSocket endpoint 및 Swagger는 정상 동작)