### PR TITLE
socket-service Swagger에 WebSocket(STOMP) 사용 안내 추가

### DIFF
--- a/socket-service/src/main/kotlin/com/parkit/socket/api/SocketDocsController.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/api/SocketDocsController.kt
@@ -1,0 +1,57 @@
+package com.parkit.socket.api
+
+import com.parkit.socket.dto.CoachingSocketDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/socket")
+@Tag(
+	name = "웹소켓",
+	description = "Swagger(OpenAPI)는 WebSocket(STOMP) 메시지 채널을 자동으로 문서화하지 못합니다. 대신 연결 엔드포인트와 토픽/메시지 스키마를 안내하는 HTTP 문서 엔드포인트를 제공합니다.",
+)
+class SocketDocsController {
+	@GetMapping("/ws-info")
+	@Operation(
+		summary = "WebSocket(STOMP) 사용 안내",
+		description = "클라이언트가 연결해야 하는 STOMP 엔드포인트(/ws/parkit)와 subscribe/send destination 규칙을 반환합니다.",
+	)
+	fun wsInfo(): WebSocketInfoResponse = WebSocketInfoResponse(
+		stompEndpoints = listOf("/ws/parkit", "/ws/parkit-mock"),
+		applicationDestinationPrefix = "/app",
+		subscribeDestinations = listOf("/topic/coaching", "/topic/coaching-mock"),
+		messageSchemas = listOf(
+			MessageSchema(
+				name = "CoachingSocketDto",
+				description = "서버가 /topic/coaching 으로 브로드캐스트하는 코칭 메시지",
+				javaType = CoachingSocketDto::class.qualifiedName ?: "com.parkit.socket.dto.CoachingSocketDto",
+			),
+		),
+	)
+}
+
+@Schema(description = "WebSocket(STOMP) 사용 안내 응답")
+data class WebSocketInfoResponse(
+	@field:Schema(description = "SockJS/STOMP 엔드포인트 목록")
+	val stompEndpoints: List<String>,
+	@field:Schema(description = "클라이언트->서버 send prefix")
+	val applicationDestinationPrefix: String,
+	@field:Schema(description = "서버->클라이언트 subscribe destination 예시")
+	val subscribeDestinations: List<String>,
+	@field:Schema(description = "주요 메시지 스키마 목록")
+	val messageSchemas: List<MessageSchema>,
+)
+
+@Schema(description = "메시지 스키마 메타 정보")
+data class MessageSchema(
+	@field:Schema(description = "스키마 이름")
+	val name: String,
+	@field:Schema(description = "설명")
+	val description: String,
+	@field:Schema(description = "Java/Kotlin 타입 FQN")
+	val javaType: String,
+)

--- a/socket-service/src/main/kotlin/com/parkit/socket/config/SwaggerConfig.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/config/SwaggerConfig.kt
@@ -14,8 +14,8 @@ class SwaggerConfig {
             .info(
                 Info()
                     .title("Parkit Socket Service API")
-                    .description("API Documentation for Socket Service")
-                    .version("1.0.0")
+                    .description("Socket(WebSocket/STOMP) 서비스 문서")
+                    .version("v1")
             )
     }
 }

--- a/socket-service/src/main/kotlin/com/parkit/socket/dto/CoachingSocketDto.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/dto/CoachingSocketDto.kt
@@ -1,22 +1,38 @@
 package com.parkit.socket.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 /**
  * analysis-service에서 계산된 코칭 데이터
  */
+@Schema(description = "장애물 거리 정보")
 data class ObstacleDistancesDto(
+	@field:Schema(description = "전방 거리")
 	val frontDistance: Double,
+	@field:Schema(description = "후방 거리")
 	val backDistance: Double,
+	@field:Schema(description = "좌측 거리")
 	val leftDistance: Double,
+	@field:Schema(description = "우측 거리")
 	val rightDistance: Double,
 )
 
+@Schema(description = "코칭 메시지")
 data class CoachingSocketDto(
+	@field:Schema(description = "코칭 단계")
 	val step: Int,
+	@field:Schema(description = "타임스탬프(ms)")
 	val timestamp: Long,
+	@field:Schema(description = "목표 각도")
 	val targetAngle: Double,
+	@field:Schema(description = "목표 거리")
 	val targetDistance: Double,
+	@field:Schema(description = "현재 각도")
 	val currentAngle: Double,
+	@field:Schema(description = "현재 거리")
 	val currentDistance: Double,
+	@field:Schema(description = "장애물 거리")
 	val distances: ObstacleDistancesDto,
+	@field:Schema(description = "코칭 ID")
 	val coachingId: Int,
 )


### PR DESCRIPTION
## 배경
- Swagger(OpenAPI)는 WebSocket(STOMP) 채널/토픽을 자동으로 스캔해서 문서화하지 못해 UI가 비어 보입니다.

## 변경
- `GET /api/socket/ws-info` 문서 엔드포인트 추가: STOMP 엔드포인트(`/ws/parkit`, `/ws/parkit-mock`), prefix(`/app`), subscribe destination(`/topic/**`)를 반환
- DTO 스키마(`CoachingSocketDto`, `ObstacleDistancesDto`)에 Swagger 스키마 설명(한글) 추가
- Swagger 기본 설명을 한글로 보강

## 참고
- 메시지 채널을 표준적으로 문서화하려면 AsyncAPI를 별도로 쓰는 것이 가장 정확하지만, 일단 Swagger에서 확인 가능한 형태로 안내용 REST 문서를 제공합니다.