### PR TITLE
fix: 코칭ID 1~5 규칙 적용 + 장애물 거리 Int 전환

### DIFF
--- a/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/dto/CoachingSocketDto.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/dto/CoachingSocketDto.kt
@@ -4,10 +4,10 @@ package com.parkit.analysis.coaching.dto
  * socket service로 전달될 코칭 알림 이벤트
  */
 data class ObstacleDistancesDto(
-	val frontDistance: Double,
-	val backDistance: Double,
-	val leftDistance: Double,
-	val rightDistance: Double,
+	val frontDistance: Int,
+	val backDistance: Int,
+	val leftDistance: Int,
+	val rightDistance: Int,
 )
 
 data class CoachingSocketDto(

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/service/RiskDetectionService.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/service/RiskDetectionService.kt
@@ -29,30 +29,24 @@ class RiskDetectionService(
 		return createCoachingEvent(step, event, minDistance)
     }
 
-    /**
-     * 거리 데이터를 기반으로 코칭 이벤트 반환
-     */
-	fun createCoachingEvent(step: Int, event: ParkingSensorDto): CoachingSocketDto {
-		val minDistance = minDistance(event)
-		return createCoachingEvent(step, event, minDistance)
-	}
-
-        private fun createCoachingEvent(step: Int, event: ParkingSensorDto, minDistance: Double): CoachingSocketDto {
+	private fun createCoachingEvent(step: Int, event: ParkingSensorDto, minDistance: Double): CoachingSocketDto {
 		val ref = ParkingReference.getReferenceForStep(step)
 		val targetAngle = ref?.handleAngle ?: 0.0
 		val targetDistance = if (ref == null) 0.0 else {
             sqrt((event.x - ref.x).pow(2) + (event.y - ref.y).pow(2))
 		}
-		val frontGap = (event.frontDist * 100).roundToInt()
-		val backGap = (event.rearDist * 100).roundToInt()
-		val leftGap = (event.leftDist * 100).roundToInt()
-		val rightGap = (event.rightDist * 100).roundToInt()
+		val distancesCm = ObstacleDistancesDto(
+			frontDistance = (event.frontDist * 100).roundToInt(),
+			backDistance = (event.rearDist * 100).roundToInt(),
+			leftDistance = (event.leftDist * 100).roundToInt(),
+			rightDistance = (event.rightDist * 100).roundToInt(),
+		)
 
 		val coachingId = when {
-			backGap <= DANGER_LIMIT_FRONT_BACK -> 1
-			frontGap <= DANGER_LIMIT_FRONT_BACK -> 2
-			leftGap <= DANGER_LIMIT_SIDE -> 3
-			rightGap <= DANGER_LIMIT_SIDE -> 4
+			distancesCm.backDistance <= DANGER_LIMIT_FRONT_BACK -> 1
+			distancesCm.frontDistance <= DANGER_LIMIT_FRONT_BACK -> 2
+			distancesCm.leftDistance <= DANGER_LIMIT_SIDE -> 3
+			distancesCm.rightDistance <= DANGER_LIMIT_SIDE -> 4
 			else -> 5
 		}
 
@@ -63,12 +57,7 @@ class RiskDetectionService(
             targetDistance = targetDistance,
             currentAngle = event.handleAngle,
             currentDistance = minDistance,
-			distances = ObstacleDistancesDto(
-				frontDistance = frontGap,
-				backDistance = backGap,
-				leftDistance = leftGap,
-				rightDistance = rightGap,
-			),
+			distances = distancesCm,
             coachingId = coachingId,
         )
 	}

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/service/RiskDetectionService.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/service/RiskDetectionService.kt
@@ -5,6 +5,7 @@ import com.parkit.analysis.coaching.dto.ObstacleDistancesDto
 import com.parkit.analysis.kafka.dto.ParkingSensorDto
 import com.parkit.analysis.parking.domain.ParkingReference
 import org.springframework.stereotype.Service
+import kotlin.math.roundToInt
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -16,17 +17,15 @@ class RiskDetectionService(
      * 주차 센서와 장애물 간의 거리
      */
     companion object {
-        const val DANGER_THRESHOLD = 0.3    // 30cm 미만
-        const val WARNING_THRESHOLD = 1.0   // 1m 이하
+		private const val DANGER_LIMIT_FRONT_BACK = 200
+		private const val DANGER_LIMIT_SIDE = 80
     }
 
     /**
      * 주행 이벤트를 기반으로 코칭 이벤트를 계산합니다.
      */
-	fun calculate(step: Int, event: ParkingSensorDto): CoachingSocketDto? {
+	fun calculate(step: Int, event: ParkingSensorDto): CoachingSocketDto {
 		val minDistance = minDistance(event)
-		if (minDistance > WARNING_THRESHOLD) return null
-
 		return createCoachingEvent(step, event, minDistance)
     }
 
@@ -44,7 +43,18 @@ class RiskDetectionService(
 		val targetDistance = if (ref == null) 0.0 else {
             sqrt((event.x - ref.x).pow(2) + (event.y - ref.y).pow(2))
 		}
-		val coachingId = if (minDistance < DANGER_THRESHOLD) 2 else 1
+		val frontGap = (event.frontDist * 100).roundToInt()
+		val backGap = (event.rearDist * 100).roundToInt()
+		val leftGap = (event.leftDist * 100).roundToInt()
+		val rightGap = (event.rightDist * 100).roundToInt()
+
+		val coachingId = when {
+			backGap <= DANGER_LIMIT_FRONT_BACK -> 1
+			frontGap <= DANGER_LIMIT_FRONT_BACK -> 2
+			leftGap <= DANGER_LIMIT_SIDE -> 3
+			rightGap <= DANGER_LIMIT_SIDE -> 4
+			else -> 5
+		}
 
 		return CoachingSocketDto(
             step = step,
@@ -54,10 +64,10 @@ class RiskDetectionService(
             currentAngle = event.handleAngle,
             currentDistance = minDistance,
 			distances = ObstacleDistancesDto(
-				frontDistance = event.frontDist,
-				backDistance = event.rearDist,
-				leftDistance = event.leftDist,
-				rightDistance = event.rightDist,
+				frontDistance = frontGap,
+				backDistance = backGap,
+				leftDistance = leftGap,
+				rightDistance = rightGap,
 			),
             coachingId = coachingId,
         )

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/kafka/KafkaAnalysisConsumer.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/kafka/KafkaAnalysisConsumer.kt
@@ -46,11 +46,9 @@ class KafkaAnalysisConsumer(
             parkingScoringService.processParkingEvent(sessionId, event.toParkingEvent())
                 .publishOn(Schedulers.boundedElastic())
                 .doOnNext { result ->
-                    riskDetectionService.calculate(result.step, event)
-                        ?.let { coaching ->
-                            val coachingJson = objectMapper.writeValueAsString(coaching)
-                            kafkaTemplate.send(coachingEventTopic, sessionId, coachingJson)
-                        }
+							val coaching = riskDetectionService.calculate(result.step, event)
+							val coachingJson = objectMapper.writeValueAsString(coaching)
+							kafkaTemplate.send(coachingEventTopic, sessionId, coachingJson)
 
                     val resultJson = objectMapper.writeValueAsString(result)
                     kafkaTemplate.send(parkingScoreResultTopic, sessionId, resultJson)

--- a/analysis-service/src/main/resources/application.yml
+++ b/analysis-service/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     mongodb:
       uri: ${PARKIT_MONGODB_URI:mongodb://mongodb-service:27017/analysis_db}
   kafka:
-    bootstrap-servers: my-kafka:9092
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     properties:
       api.version.request: true
     consumer:

--- a/analysis-service/src/test/kotlin/com/parkit/analysis/coaching/application/RiskDetectionServiceTest.kt
+++ b/analysis-service/src/test/kotlin/com/parkit/analysis/coaching/application/RiskDetectionServiceTest.kt
@@ -15,20 +15,20 @@ class RiskDetectionServiceTest : BehaviorSpec({
     )
 
 	Given("주차 센서 이벤트가 주어졌을 때") {
-		When("거리가 2.0m (안전 거리)인 경우") {
-			val event = createMockEvent(2.0)
+		When("거리가 3.0m (안전 거리)인 경우") {
+			val event = createMockEvent(3.0)
 			val result = riskDetectionService.createCoachingEvent(step = 1, event = event)
 
 			Then("현재 거리/센서 거리가 DTO에 반영된다") {
-				result.currentDistance shouldBe 2.0
-				result.distances.frontDistance shouldBe 2.0
-				result.distances.backDistance shouldBe 2.0
-				result.distances.leftDistance shouldBe 2.0
-				result.distances.rightDistance shouldBe 2.0
+				result.currentDistance shouldBe 3.0
+				result.distances.frontDistance shouldBe 300
+				result.distances.backDistance shouldBe 300
+				result.distances.leftDistance shouldBe 300
+				result.distances.rightDistance shouldBe 300
 			}
 
-			Then("calculate는 null을 반환한다") {
-				riskDetectionService.calculate(step = 1, event = event) shouldBe null
+			Then("calculate는 양호 상태(5)를 반환한다") {
+				riskDetectionService.calculate(step = 1, event = event).coachingId shouldBe 5
 			}
 		}
 
@@ -41,7 +41,7 @@ class RiskDetectionServiceTest : BehaviorSpec({
 			}
 
 			Then("calculate는 코칭 이벤트를 반환한다") {
-				riskDetectionService.calculate(step = 1, event = event)?.currentDistance shouldBe 0.8
+				riskDetectionService.calculate(step = 1, event = event).currentDistance shouldBe 0.8
 			}
 		}
 

--- a/analysis-service/src/test/kotlin/com/parkit/analysis/coaching/application/RiskDetectionServiceTest.kt
+++ b/analysis-service/src/test/kotlin/com/parkit/analysis/coaching/application/RiskDetectionServiceTest.kt
@@ -17,7 +17,7 @@ class RiskDetectionServiceTest : BehaviorSpec({
 	Given("주차 센서 이벤트가 주어졌을 때") {
 		When("거리가 3.0m (안전 거리)인 경우") {
 			val event = createMockEvent(3.0)
-			val result = riskDetectionService.createCoachingEvent(step = 1, event = event)
+			val result = riskDetectionService.calculate(step = 1, event = event)
 
 			Then("현재 거리/센서 거리가 DTO에 반영된다") {
 				result.currentDistance shouldBe 3.0
@@ -34,7 +34,7 @@ class RiskDetectionServiceTest : BehaviorSpec({
 
 		When("거리가 0.8m (주의 거리)인 경우") {
 			val event = createMockEvent(0.8)
-			val result = riskDetectionService.createCoachingEvent(step = 1, event = event)
+			val result = riskDetectionService.calculate(step = 1, event = event)
 
 			Then("currentDistance에 최소 거리가 들어간다") {
 				result.currentDistance shouldBe 0.8
@@ -47,7 +47,7 @@ class RiskDetectionServiceTest : BehaviorSpec({
 
 		When("거리가 0.2m (위험 거리)인 경우") {
 			val event = createMockEvent(0.2)
-			val result = riskDetectionService.createCoachingEvent(step = 1, event = event)
+			val result = riskDetectionService.calculate(step = 1, event = event)
 
 			Then("currentDistance에 최소 거리가 들어간다") {
 				result.currentDistance shouldBe 0.2

--- a/socket-service/src/main/kotlin/com/parkit/socket/controller/MockCoachingController.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/controller/MockCoachingController.kt
@@ -6,6 +6,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Controller
+import kotlin.random.Random
 
 @Controller
 @EnableScheduling
@@ -15,25 +16,40 @@ class MockCoachingController(
 
 	companion object {
 		private const val TOPIC_DESTINATION = "/topic/coaching-mock"
+		private const val DANGER_LIMIT_FRONT_BACK = 200
+		private const val DANGER_LIMIT_SIDE = 80
 	}
 
     // 1초마다 가짜 주차 코칭 데이터를 브로드캐스트
     @Scheduled(fixedRate = 1000)
     fun sendMockCoachingData() {
+		val frontGap = Random.nextInt(50, 301)
+		val backGap = Random.nextInt(50, 301)
+		val leftGap = Random.nextInt(30, 151)
+		val rightGap = Random.nextInt(30, 151)
+
+		val coachingId = when {
+			backGap <= DANGER_LIMIT_FRONT_BACK -> 1
+			frontGap <= DANGER_LIMIT_FRONT_BACK -> 2
+			leftGap <= DANGER_LIMIT_SIDE -> 3
+			rightGap <= DANGER_LIMIT_SIDE -> 4
+			else -> 5
+		}
+
 		val mockData = CoachingSocketDto(
 			step = 1,
 			timestamp = System.currentTimeMillis(),
 			targetAngle = 0.0,
 			targetDistance = 1.0,
 			currentAngle = 0.0,
-			currentDistance = Math.random() * 2,
+			currentDistance = Random.nextDouble(0.0, 2.0),
 			distances = ObstacleDistancesDto(
-				frontDistance = Math.random() * 2,
-				backDistance = Math.random() * 2,
-				leftDistance = Math.random() * 2,
-				rightDistance = Math.random() * 2,
+				frontDistance = frontGap,
+				backDistance = backGap,
+				leftDistance = leftGap,
+				rightDistance = rightGap,
 			),
-			coachingId = 1,
+			coachingId = coachingId,
 		)
 
         // 브로커의 /topic/coaching 을 구독하는 클라이언트들에게 전달

--- a/socket-service/src/main/kotlin/com/parkit/socket/dto/CoachingSocketDto.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/dto/CoachingSocketDto.kt
@@ -8,13 +8,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "장애물 거리 정보")
 data class ObstacleDistancesDto(
 	@field:Schema(description = "전방 거리")
-	val frontDistance: Double,
+	val frontDistance: Int,
 	@field:Schema(description = "후방 거리")
-	val backDistance: Double,
+	val backDistance: Int,
 	@field:Schema(description = "좌측 거리")
-	val leftDistance: Double,
+	val leftDistance: Int,
 	@field:Schema(description = "우측 거리")
-	val rightDistance: Double,
+	val rightDistance: Int,
 )
 
 @Schema(description = "코칭 메시지")

--- a/socket-service/src/main/resources/application.yml
+++ b/socket-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: socket-service
 
   kafka:
-    bootstrap-servers: my-kafka:9092
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
       group-id: socket-group
       auto-offset-reset: latest


### PR DESCRIPTION
## 변경
- coachingId 범위를 1~5로 통일
  - 후(<=200) -> 1
  - 전(<=200) -> 2
  - 좌(<=80) -> 3
  - 우(<=80) -> 4
  - 정상 -> 5
- 장애물 거리(obstacle distances) 타입을 Double -> Int로 변경
  - analysis-service에서 센서 거리(m)를 cm(Int)로 변환하여 전송
- socket-service MockCoachingController도 동일 규칙/범위로 생성

## 영향
- Kafka로 전달되는 코칭 메시지의 distances 필드 타입이 Int로 변경됩니다.