### PR TITLE
chore: mock 대신 실제 코칭 스트림 사용

### DIFF
--- a/socket-service/src/main/kotlin/com/parkit/socket/api/SocketDocsController.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/api/SocketDocsController.kt
@@ -4,6 +4,7 @@ import com.parkit.socket.dto.CoachingSocketDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -15,15 +16,26 @@ import org.springframework.web.bind.annotation.RestController
 	description = "Swagger(OpenAPI)는 WebSocket(STOMP) 메시지 채널을 자동으로 문서화하지 못합니다. 대신 연결 엔드포인트와 토픽/메시지 스키마를 안내하는 HTTP 문서 엔드포인트를 제공합니다.",
 )
 class SocketDocsController {
+	@Value("\${parkit.mock.coaching.enabled:false}")
+	private val mockEnabled: Boolean = false
+
 	@GetMapping("/ws-info")
 	@Operation(
 		summary = "WebSocket(STOMP) 사용 안내",
 		description = "클라이언트가 연결해야 하는 STOMP 엔드포인트(/ws/parkit)와 subscribe/send destination 규칙을 반환합니다.",
 	)
-	fun wsInfo(): WebSocketInfoResponse = WebSocketInfoResponse(
-		stompEndpoints = listOf("/ws/parkit", "/ws/parkit-mock"),
+	fun wsInfo(): WebSocketInfoResponse {
+		val endpoints = mutableListOf("/ws/parkit")
+		val subscribe = mutableListOf("/topic/coaching")
+		if (mockEnabled) {
+			endpoints.add("/ws/parkit-mock")
+			subscribe.add("/topic/coaching-mock")
+		}
+
+		return WebSocketInfoResponse(
+			stompEndpoints = endpoints,
 		applicationDestinationPrefix = "/app",
-		subscribeDestinations = listOf("/topic/coaching", "/topic/coaching-mock"),
+			subscribeDestinations = subscribe,
 		messageSchemas = listOf(
 			MessageSchema(
 				name = "CoachingSocketDto",
@@ -31,7 +43,8 @@ class SocketDocsController {
 				javaType = CoachingSocketDto::class.qualifiedName ?: "com.parkit.socket.dto.CoachingSocketDto",
 			),
 		),
-	)
+		)
+	}
 }
 
 @Schema(description = "WebSocket(STOMP) 사용 안내 응답")

--- a/socket-service/src/main/kotlin/com/parkit/socket/config/WebSocketConfig.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/config/WebSocketConfig.kt
@@ -23,10 +23,5 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
 		registry.addEndpoint("/ws/parkit")
 			.setAllowedOriginPatterns("*") // 실제 운영 시에는 프론트엔드 도메인으로 제한
 			.withSockJS() // SockJS 폴백 옵션 활성화
-
-		// 로컬 테스트/데모용 mock 엔드포인트
-		registry.addEndpoint("/ws/parkit-mock")
-			.setAllowedOriginPatterns("*")
-			.withSockJS()
 	}
 }

--- a/socket-service/src/main/kotlin/com/parkit/socket/controller/MockCoachingController.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/controller/MockCoachingController.kt
@@ -2,6 +2,7 @@ package com.parkit.socket.controller
 
 import com.parkit.socket.dto.CoachingSocketDto
 import com.parkit.socket.dto.ObstacleDistancesDto
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
@@ -10,6 +11,7 @@ import kotlin.random.Random
 
 @Controller
 @EnableScheduling
+@ConditionalOnProperty(prefix = "parkit.mock.coaching", name = ["enabled"], havingValue = "true")
 class MockCoachingController(
     private val messagingTemplate: SimpMessagingTemplate
 ) {

--- a/socket-service/src/main/kotlin/com/parkit/socket/mock/CoachingScheduler.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/mock/CoachingScheduler.kt
@@ -1,4 +1,4 @@
-package com.parkit.socket.controller
+package com.parkit.socket.mock
 
 import com.parkit.socket.dto.CoachingSocketDto
 import com.parkit.socket.dto.ObstacleDistancesDto
@@ -6,25 +6,23 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Controller
+import org.springframework.stereotype.Component
 import kotlin.random.Random
 
-@Controller
+@Component
 @EnableScheduling
 @ConditionalOnProperty(prefix = "parkit.mock.coaching", name = ["enabled"], havingValue = "true")
-class MockCoachingController(
-    private val messagingTemplate: SimpMessagingTemplate
+class CoachingScheduler(
+	private val messagingTemplate: SimpMessagingTemplate,
 ) {
-
 	companion object {
 		private const val TOPIC_DESTINATION = "/topic/coaching-mock"
 		private const val DANGER_LIMIT_FRONT_BACK = 200
 		private const val DANGER_LIMIT_SIDE = 80
 	}
 
-    // 1초마다 가짜 주차 코칭 데이터를 브로드캐스트
-    @Scheduled(fixedRate = 1000)
-    fun sendMockCoachingData() {
+	@Scheduled(fixedRate = 1000)
+	fun sendMockCoachingData() {
 		val frontGap = Random.nextInt(50, 301)
 		val backGap = Random.nextInt(50, 301)
 		val leftGap = Random.nextInt(30, 151)
@@ -54,7 +52,6 @@ class MockCoachingController(
 			coachingId = coachingId,
 		)
 
-        // 브로커의 /topic/coaching 을 구독하는 클라이언트들에게 전달
 		messagingTemplate.convertAndSend(TOPIC_DESTINATION, mockData)
-    }
+	}
 }

--- a/socket-service/src/main/kotlin/com/parkit/socket/mock/MockWebSocketConfig.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/mock/MockWebSocketConfig.kt
@@ -1,0 +1,16 @@
+package com.parkit.socket.mock
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@ConditionalOnProperty(prefix = "parkit.mock.coaching", name = ["enabled"], havingValue = "true")
+class MockWebSocketConfig : WebSocketMessageBrokerConfigurer {
+	override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+		registry.addEndpoint("/ws/parkit-mock")
+			.setAllowedOriginPatterns("*")
+			.withSockJS()
+	}
+}

--- a/socket-service/src/main/resources/application.yml
+++ b/socket-service/src/main/resources/application.yml
@@ -17,6 +17,9 @@ parkit:
   kafka:
     topics:
       coachingEvent: coaching-event
+  mock:
+    coaching:
+      enabled: false
 
 logging:
   level:


### PR DESCRIPTION
## 의도
- 실제 계산된 코칭 이벤트는 Kafka `coaching-event` -> socket-service consumer -> `/topic/coaching` 으로 브로드캐스트됩니다.
- 기존 mock 스케줄러가 항상 켜져 있으면(특히 데모 환경) 클라이언트가 mock 경로로만 붙어서 실제 데이터가 안 보이는 혼선이 생길 수 있어 기본값을 꺼둡니다.

## 변경
- `MockCoachingController`를 `parkit.mock.coaching.enabled=true`일 때만 활성화
- 기본값은 `false`

## 사용법
- mock을 쓰려면 socket-service 설정에 `parkit.mock.coaching.enabled=true`를 추가하세요.
- 실제 데이터는 `/ws/parkit` + subscribe `/topic/coaching` 로 받습니다.