### PR TITLE
analysis-service: MongoDB URI를 SPRING_DATA_MONGODB_URI로 통일

### DIFF
--- a/analysis-service/src/main/resources/application.yml
+++ b/analysis-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       host: localhost
       port: 6379
     mongodb:
-      uri: ${PARKIT_MONGODB_URI:mongodb://mongodb-service:27017/analysis_db}
+      uri: ${SPRING_DATA_MONGODB_URI:mongodb://mongodb:27017/parkit}
   kafka:
     bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     properties:


### PR DESCRIPTION
## 문제
- Kubernetes에서 MongoDB를 `localhost:27017`로 붙으면 Pod 자기 자신을 의미해서 연결이 실패합니다.
- 배포에서 이미 `SPRING_DATA_MONGODB_URI=mongodb://mongodb:27017/parkit`를 주입하고 있으므로, 애플리케이션 설정도 그 변수에 맞춰야 합니다.

## 변경
- `analysis-service/src/main/resources/application.yml`
  - `spring.data.mongodb.uri`를 `${SPRING_DATA_MONGODB_URI:mongodb://mongodb:27017/parkit}`로 변경

## 배포
- Deployment env 예시
  - `SPRING_DATA_MONGODB_URI=mongodb://mongodb:27017/parkit`