### PR TITLE
report-service: RUNNING 세션에 첫 센서 JSON 자동 저장

### DIFF
--- a/report-service/src/main/kotlin/com/parkit/report/driving/persistence/document/DrivingSessionDocument.kt
+++ b/report-service/src/main/kotlin/com/parkit/report/driving/persistence/document/DrivingSessionDocument.kt
@@ -23,4 +23,8 @@ data class DrivingSessionDocument(
 	val stoppedAt: Instant?,
 	@field:Schema(description = "프론트에서 계산한 점수")
 	val frontendScore: Double?,
+	@field:Schema(description = "세션 시작 후 첫 센서 원본 JSON")
+	val firstSensorPayloadJson: String?,
+	@field:Schema(description = "첫 센서 수신 시간(UTC)")
+	val firstSensorReceivedAt: Instant?,
 )

--- a/report-service/src/main/kotlin/com/parkit/report/driving/service/DrivingSessionService.kt
+++ b/report-service/src/main/kotlin/com/parkit/report/driving/service/DrivingSessionService.kt
@@ -4,16 +4,23 @@ import com.parkit.report.driving.domain.DrivingSessionStatus
 import com.parkit.report.driving.persistence.document.DrivingSessionDocument
 import com.parkit.report.driving.persistence.repository.DrivingSessionMongoRepository
 
-import org.springframework.http.HttpStatus
+import org.springframework.data.mongodb.core.FindAndModifyOptions
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
+import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
 
 @Service
 class DrivingSessionService(
 	private val drivingSessionRepository: DrivingSessionMongoRepository,
+	private val mongoTemplate: MongoTemplate,
 	private val clock: Clock = Clock.systemUTC(),
 ) {
 	fun start(userId: String?): DrivingSessionDocument {
@@ -30,6 +37,8 @@ class DrivingSessionService(
 			startedAt = now,
 			stoppedAt = null,
 			frontendScore = null,
+			firstSensorPayloadJson = null,
+			firstSensorReceivedAt = null,
 		)
 		return drivingSessionRepository.save(session)
 	}
@@ -53,4 +62,29 @@ class DrivingSessionService(
 	fun get(sessionId: String): DrivingSessionDocument =
 		drivingSessionRepository.findById(sessionId)
 			.orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found") }
+
+	fun attachFirstSensorPayloadIfAbsent(messageJson: String): DrivingSessionDocument? {
+		val now = Instant.now(clock)
+		val query = Query()
+			.addCriteria(Criteria.where("status").`is`(DrivingSessionStatus.RUNNING))
+			.addCriteria(
+				Criteria().orOperator(
+					Criteria.where("firstSensorPayloadJson").exists(false),
+					Criteria.where("firstSensorPayloadJson").`is`(null),
+				),
+			)
+			.with(Sort.by(Sort.Direction.DESC, "startedAt"))
+			.limit(1)
+
+		val update = Update()
+			.set("firstSensorPayloadJson", messageJson)
+			.set("firstSensorReceivedAt", now)
+
+		return mongoTemplate.findAndModify(
+			query,
+			update,
+			FindAndModifyOptions.options().returnNew(true),
+			DrivingSessionDocument::class.java,
+		)
+	}
 }

--- a/report-service/src/main/kotlin/com/parkit/report/kafka/SensorTopicConsumer.kt
+++ b/report-service/src/main/kotlin/com/parkit/report/kafka/SensorTopicConsumer.kt
@@ -1,0 +1,27 @@
+package com.parkit.report.kafka
+
+import com.parkit.report.driving.service.DrivingSessionService
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "parkit.kafka", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+class SensorTopicConsumer(
+	private val drivingSessionService: DrivingSessionService,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	@KafkaListener(topics = ["\${parkit.kafka.topics.sensor}"])
+	fun consume(message: String) {
+		try {
+			val updated = drivingSessionService.attachFirstSensorPayloadIfAbsent(message)
+			if (updated != null) {
+				log.info("Attached first sensor payload to sessionId={}", updated.id)
+			}
+		} catch (e: Exception) {
+			log.error("Failed to consume sensor-topic message", e)
+		}
+	}
+}

--- a/report-service/src/main/resources/application.yml
+++ b/report-service/src/main/resources/application.yml
@@ -7,10 +7,10 @@ spring:
   
   data:
     mongodb:
-      uri: mongodb://mongodb:27017/parkit
+      uri: ${SPRING_DATA_MONGODB_URI:mongodb://mongodb:27017/parkit}
 
   kafka:
-    bootstrap-servers: my-kafka:9092
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
       group-id: report-group
       auto-offset-reset: latest
@@ -28,3 +28,9 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v3/api-docs
+
+parkit:
+  kafka:
+    enabled: true
+    topics:
+      sensor: sensor-topic

--- a/report-service/src/test/kotlin/com/parkit/report/ReportServiceApplicationTests.kt
+++ b/report-service/src/test/kotlin/com/parkit/report/ReportServiceApplicationTests.kt
@@ -3,7 +3,11 @@ package com.parkit.report
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
+@SpringBootTest(
+	properties = [
+		"parkit.kafka.enabled=false",
+	],
+)
 class ReportServiceApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 목표
- 세션 시작(start) 이후 들어오는 sensor-topic의 첫 메시지 원본 JSON을 세션에 저장
- stop 요청의 frontendScore와 함께 MongoDB에서 리포트 조회 가능하게 구성

## 구현
- MongoDB `driving_sessions`에 필드 추가
  - `firstSensorPayloadJson` (원본 JSON)
  - `firstSensorReceivedAt`
- report-service가 Kafka `sensor-topic`을 직접 consume
  - 최근 RUNNING 세션 중 `firstSensorPayloadJson`이 비어있는 경우에만 1회 저장
  - `MongoTemplate.findAndModify`로 원자적으로 업데이트(중복 저장 방지)

## 설정
- `parkit.kafka.topics.sensor: sensor-topic`
- `spring.kafka.bootstrap-servers`, `spring.data.mongodb.uri`는 env로 오버라이드 가능

## 테스트
- `@SpringBootTest`에서 `parkit.kafka.enabled=false`로 listener 비활성화하여 로컬/CI에서 Kafka 없이도 contextLoads 통과