### PR TITLE
analysis-service: MongoDB 설정/의존성 제거

### DIFF
--- a/analysis-service/build.gradle.kts
+++ b/analysis-service/build.gradle.kts
@@ -20,9 +20,9 @@ repositories {
 }
 
 
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
-	implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
 	implementation("org.springframework.boot:spring-boot-starter-kafka")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.5")

--- a/analysis-service/src/main/resources/application.yml
+++ b/analysis-service/src/main/resources/application.yml
@@ -9,8 +9,6 @@ spring:
     redis:
       host: localhost
       port: 6379
-    mongodb:
-      uri: ${SPRING_DATA_MONGODB_URI:mongodb://mongodb:27017/parkit}
   kafka:
     bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     properties:


### PR DESCRIPTION
## 배경
- analysis-service는 현재 MongoDB를 직접 사용하지 않습니다(Repository/Template/Document 없음).
- 불필요한 Mongo 의존성과 설정은 배포 환경에서 접속 설정 실수로 인한 장애 가능성을 키웁니다.

## 변경
- `analysis-service/build.gradle.kts`: `spring-boot-starter-data-mongodb-reactive` 제거
- `analysis-service/src/main/resources/application.yml`: `spring.data.mongodb` 설정 제거

## 영향
- analysis-service는 Kafka/Redis/HTTP(WebFlux)만 사용합니다.