### PR TITLE
report-service: DrivingSession API CORS 허용

### DIFF
--- a/report-service/src/main/kotlin/com/parkit/report/driving/api/DrivingSessionController.kt
+++ b/report-service/src/main/kotlin/com/parkit/report/driving/api/DrivingSessionController.kt
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/driving-sessions")
+@CrossOrigin(origins = ["*"])
 @Tag(
 	name = "주행 리포트",
 	description = "주행 세션(start/stop), 센서 로그, 프론트 점수(frontendScore)를 저장/조회합니다.",


### PR DESCRIPTION
`report-service/src/main/kotlin/com/parkit/report/driving/api/DrivingSessionController.kt`에 `@CrossOrigin(origins = ["*"])`를 추가해 브라우저 클라이언트에서 직접 호출 가능하게 했습니다.