### PR TITLE
report-service: Mongo 설정을 spring.mongodb.uri로 변경

### DIFF
--- a/report-service/src/main/resources/application.yml
+++ b/report-service/src/main/resources/application.yml
@@ -4,10 +4,9 @@ server:
 spring:
   application:
     name: report-service
-  
-  data:
-    mongodb:
-      uri: ${SPRING_DATA_MONGODB_URI:mongodb://mongodb:27017/parkit}
+
+  mongodb:
+    uri: ${SPRING_MONGODB_URI:mongodb://mongodb:27017/parkit}
 
   kafka:
     bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}


### PR DESCRIPTION
## 배경
- Spring Boot 4부터 `spring.data.mongodb.*` 설정키가 deprecated(level=error)이고, `spring.mongodb.*`로 이동했습니다.
- 현재 배포는 `SPRING_DATA_MONGODB_URI`를 넣어도 설정이 적용되지 않아 기본값(localhost:27017)로 붙는 로그가 발생했습니다.

## 변경
- `report-service/src/main/resources/application.yml`
  - `spring.data.mongodb.uri` -> `spring.mongodb.uri`
  - env도 `SPRING_MONGODB_URI`로 오버라이드하도록 변경

## 배포 가이드
- Deployment env를 다음으로 변경하세요
  - `SPRING_MONGODB_URI=mongodb://admin:password@mongodb:27017/parkit?authSource=admin`
- 기존 `SPRING_DATA_MONGODB_URI`는 제거 권장