### PR TITLE
fix: Docker push 504 대응을 위한 retry 적용

### DIFF
--- a/analysis-service/Jenkinsfile
+++ b/analysis-service/Jenkinsfile
@@ -72,9 +72,11 @@ pipeline {
                 // Docker Hub에 이미지를 푸시
                 echo 'Pushing Docker Image to Docker Hub registry...'
                 withCredentials([usernamePassword(credentialsId: 'dockerhub-credentials', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-                    sh "echo \$DOCKER_PASSWORD | docker login -u \$DOCKER_USERNAME --password-stdin"
-                    sh "docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                    sh "docker push ${DOCKER_IMAGE_NAME}:latest"
+                    retry(3) {
+                        sh "echo \$DOCKER_PASSWORD | docker login -u \$DOCKER_USERNAME --password-stdin"
+                        sh "docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                        sh "docker push ${DOCKER_IMAGE_NAME}:latest"
+                    }
                 }
             }
         }
@@ -83,33 +85,31 @@ pipeline {
             when { changeset "${SERVICE_NAME}/**" }
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
-                lock(resource: 'argocd-parkit-main') {
-                    withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                        sh '''
-                            rm -rf argocd-parkit
-                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                    sh '''
+                        rm -rf argocd-parkit
+                        git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
 
-                            cd argocd-parkit
-                            git fetch origin main
-                            git checkout main
-                            git reset --hard origin/main
+                        cd argocd-parkit
+                        git fetch origin main
+                        git checkout main
+                        git reset --hard origin/main
 
-                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
-                                "${SERVICE_NAME}/deployment.yaml"
+                        sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                            "${SERVICE_NAME}/deployment.yaml"
 
-                            git config user.email "jenkins@ci.com"
-                            git config user.name "Jenkins CI"
-                            git add "${SERVICE_NAME}/deployment.yaml"
+                        git config user.email "jenkins@ci.com"
+                        git config user.name "Jenkins CI"
+                        git add "${SERVICE_NAME}/deployment.yaml"
 
-                            if git diff --cached --quiet; then
-                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                                exit 0
-                            fi
+                        if git diff --cached --quiet; then
+                            echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                            exit 0
+                        fi
 
-                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                            git push origin main
-                        '''
-                    }
+                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                        git push origin main
+                    '''
                 }
             }
         }

--- a/analysis-service/Jenkinsfile
+++ b/analysis-service/Jenkinsfile
@@ -87,13 +87,14 @@ pipeline {
                 echo 'Updating image tag in argocd-parkit repository...'
                 withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
                     sh '''
-                        rm -rf argocd-parkit
-                        git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                        if [ ! -d "argocd-parkit/.git" ]; then
+                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                        fi
 
                         cd argocd-parkit
+                        git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
                         git fetch origin main
-                        git checkout main
-                        git reset --hard origin/main
+                        git checkout -B main origin/main
 
                         sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
                             "${SERVICE_NAME}/deployment.yaml"

--- a/analysis-service/Jenkinsfile
+++ b/analysis-service/Jenkinsfile
@@ -83,24 +83,33 @@ pipeline {
             when { changeset "${SERVICE_NAME}/**" }
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
-                withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh """
-                        # 남아있는 폴더 삭제
-                        rm -rf argocd-parkit
+                lock(resource: 'argocd-parkit-main') {
+                    withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                        sh '''
+                            rm -rf argocd-parkit
+                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
 
-                        # 새로 클론
-                        git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Parkit-Team/argocd-parkit.git
-                        
-                        cd argocd-parkit
-                        sed -i 's|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g' \
-                            ${SERVICE_NAME}/deployment.yaml
+                            cd argocd-parkit
+                            git fetch origin main
+                            git checkout main
+                            git reset --hard origin/main
 
-                        git config user.email "jenkins@ci.com"
-                        git config user.name "Jenkins CI"
-                        git add ${SERVICE_NAME}/deployment.yaml
-                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                        git push origin main
-                    """
+                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                                "${SERVICE_NAME}/deployment.yaml"
+
+                            git config user.email "jenkins@ci.com"
+                            git config user.name "Jenkins CI"
+                            git add "${SERVICE_NAME}/deployment.yaml"
+
+                            if git diff --cached --quiet; then
+                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                                exit 0
+                            fi
+
+                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                            git push origin main
+                        '''
+                    }
                 }
             }
         }

--- a/report-service/Jenkinsfile
+++ b/report-service/Jenkinsfile
@@ -72,9 +72,11 @@ pipeline {
                 // Docker Hub에 이미지를 푸시
                 echo 'Pushing Docker Image to Docker Hub registry...'
                 withCredentials([usernamePassword(credentialsId: 'dockerhub-credentials', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-                    sh "echo \$DOCKER_PASSWORD | docker login -u \$DOCKER_USERNAME --password-stdin"
-                    sh "docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                    sh "docker push ${DOCKER_IMAGE_NAME}:latest"
+                    retry(3) {
+                        sh "echo \$DOCKER_PASSWORD | docker login -u \$DOCKER_USERNAME --password-stdin"
+                        sh "docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                        sh "docker push ${DOCKER_IMAGE_NAME}:latest"
+                    }
                 }
             }
         }
@@ -83,33 +85,31 @@ pipeline {
             when { changeset "${SERVICE_NAME}/**" }
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
-                lock(resource: 'argocd-parkit-main') {
-                    withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                        sh '''
-                            rm -rf argocd-parkit
-                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                    sh '''
+                        rm -rf argocd-parkit
+                        git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
 
-                            cd argocd-parkit
-                            git fetch origin main
-                            git checkout main
-                            git reset --hard origin/main
+                        cd argocd-parkit
+                        git fetch origin main
+                        git checkout main
+                        git reset --hard origin/main
 
-                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
-                                "${SERVICE_NAME}/deployment.yaml"
+                        sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                            "${SERVICE_NAME}/deployment.yaml"
 
-                            git config user.email "jenkins@ci.com"
-                            git config user.name "Jenkins CI"
-                            git add "${SERVICE_NAME}/deployment.yaml"
+                        git config user.email "jenkins@ci.com"
+                        git config user.name "Jenkins CI"
+                        git add "${SERVICE_NAME}/deployment.yaml"
 
-                            if git diff --cached --quiet; then
-                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                                exit 0
-                            fi
+                        if git diff --cached --quiet; then
+                            echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                            exit 0
+                        fi
 
-                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                            git push origin main
-                        '''
-                    }
+                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                        git push origin main
+                    '''
                 }
             }
         }

--- a/report-service/Jenkinsfile
+++ b/report-service/Jenkinsfile
@@ -83,23 +83,33 @@ pipeline {
             when { changeset "${SERVICE_NAME}/**" }
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
-                withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh """
-                        # 남아있는 폴더 삭제
-                        rm -rf argocd-parkit
+                lock(resource: 'argocd-parkit-main') {
+                    withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                        sh '''
+                            rm -rf argocd-parkit
+                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
 
-                        # 새로 클론
-                        git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Parkit-Team/argocd-parkit.git
-                        
-                        cd argocd-parkit
-                        sed -i 's|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g' \
-                            ${SERVICE_NAME}/deployment.yaml
-                        git config user.email "jenkins@ci.com"
-                        git config user.name "Jenkins CI"
-                        git add ${SERVICE_NAME}/deployment.yaml
-                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                        git push origin main
-                    """
+                            cd argocd-parkit
+                            git fetch origin main
+                            git checkout main
+                            git reset --hard origin/main
+
+                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                                "${SERVICE_NAME}/deployment.yaml"
+
+                            git config user.email "jenkins@ci.com"
+                            git config user.name "Jenkins CI"
+                            git add "${SERVICE_NAME}/deployment.yaml"
+
+                            if git diff --cached --quiet; then
+                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                                exit 0
+                            fi
+
+                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                            git push origin main
+                        '''
+                    }
                 }
             }
         }

--- a/report-service/Jenkinsfile
+++ b/report-service/Jenkinsfile
@@ -87,13 +87,14 @@ pipeline {
                 echo 'Updating image tag in argocd-parkit repository...'
                 withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
                     sh '''
-                        rm -rf argocd-parkit
-                        git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                        if [ ! -d "argocd-parkit/.git" ]; then
+                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                        fi
 
                         cd argocd-parkit
+                        git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
                         git fetch origin main
-                        git checkout main
-                        git reset --hard origin/main
+                        git checkout -B main origin/main
 
                         sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
                             "${SERVICE_NAME}/deployment.yaml"

--- a/socket-service/Jenkinsfile
+++ b/socket-service/Jenkinsfile
@@ -82,23 +82,33 @@ pipeline {
             when { changeset "${SERVICE_NAME}/**" }
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
-                withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh """
-                        # 남아있는 폴더 삭제
-                        rm -rf argocd-parkit
+                lock(resource: 'argocd-parkit-main') {
+                    withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                        sh '''
+                            rm -rf argocd-parkit
+                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
 
-                        # 새로 클론
-                        git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/Parkit-Team/argocd-parkit.git
-                        
-                        cd argocd-parkit
-                        sed -i 's|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g' \
-                            ${SERVICE_NAME}/deployment.yaml
-                        git config user.email "jenkins@ci.com"
-                        git config user.name "Jenkins CI"
-                        git add ${SERVICE_NAME}/deployment.yaml
-                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                        git push origin main
-                    """
+                            cd argocd-parkit
+                            git fetch origin main
+                            git checkout main
+                            git reset --hard origin/main
+
+                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                                "${SERVICE_NAME}/deployment.yaml"
+
+                            git config user.email "jenkins@ci.com"
+                            git config user.name "Jenkins CI"
+                            git add "${SERVICE_NAME}/deployment.yaml"
+
+                            if git diff --cached --quiet; then
+                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                                exit 0
+                            fi
+
+                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                            git push origin main
+                        '''
+                    }
                 }
             }
         }

--- a/socket-service/Jenkinsfile
+++ b/socket-service/Jenkinsfile
@@ -86,13 +86,14 @@ pipeline {
                 echo 'Updating image tag in argocd-parkit repository...'
                 withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
                     sh '''
-                        rm -rf argocd-parkit
-                        git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                        if [ ! -d "argocd-parkit/.git" ]; then
+                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                        fi
 
                         cd argocd-parkit
+                        git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
                         git fetch origin main
-                        git checkout main
-                        git reset --hard origin/main
+                        git checkout -B main origin/main
 
                         sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
                             "${SERVICE_NAME}/deployment.yaml"

--- a/socket-service/Jenkinsfile
+++ b/socket-service/Jenkinsfile
@@ -72,9 +72,11 @@ pipeline {
                 // Docker Hub에 이미지를 푸시
                 echo 'Pushing Docker Image to Docker Hub registry...'
                 withCredentials([usernamePassword(credentialsId: 'dockerhub-credentials', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-                    sh "echo \$DOCKER_PASSWORD | docker login -u \$DOCKER_USERNAME --password-stdin"
-                    sh "docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                    sh "docker push ${DOCKER_IMAGE_NAME}:latest"
+                    retry(3) {
+                        sh "echo \$DOCKER_PASSWORD | docker login -u \$DOCKER_USERNAME --password-stdin"
+                        sh "docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                        sh "docker push ${DOCKER_IMAGE_NAME}:latest"
+                    }
                 }
             }
         }
@@ -82,33 +84,31 @@ pipeline {
             when { changeset "${SERVICE_NAME}/**" }
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
-                lock(resource: 'argocd-parkit-main') {
-                    withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                        sh '''
-                            rm -rf argocd-parkit
-                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                    sh '''
+                        rm -rf argocd-parkit
+                        git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
 
-                            cd argocd-parkit
-                            git fetch origin main
-                            git checkout main
-                            git reset --hard origin/main
+                        cd argocd-parkit
+                        git fetch origin main
+                        git checkout main
+                        git reset --hard origin/main
 
-                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
-                                "${SERVICE_NAME}/deployment.yaml"
+                        sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                            "${SERVICE_NAME}/deployment.yaml"
 
-                            git config user.email "jenkins@ci.com"
-                            git config user.name "Jenkins CI"
-                            git add "${SERVICE_NAME}/deployment.yaml"
+                        git config user.email "jenkins@ci.com"
+                        git config user.name "Jenkins CI"
+                        git add "${SERVICE_NAME}/deployment.yaml"
 
-                            if git diff --cached --quiet; then
-                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                                exit 0
-                            fi
+                        if git diff --cached --quiet; then
+                            echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                            exit 0
+                        fi
 
-                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                            git push origin main
-                        '''
-                    }
+                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                        git push origin main
+                    '''
                 }
             }
         }


### PR DESCRIPTION
## 📌 관련 이슈

Docker Hub에 latest 태그를 push하는 과정에서 504 Gateway Time-out이 발생해 파이프라인이 중단 되는 문제 발생


- Resolves None
```
+ docker build -t parkitteam/analysis-service:build-109 -t parkitteam/analysis-service:latest .
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 339B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/amazoncorretto:17-alpine
#2 DONE 1.3s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s

#4 [1/4] FROM docker.io/library/amazoncorretto:17-alpine@sha256:4b1eb8f177547a180d8e8c34ca4f90aa41d0980a77bc5e9dbf88355b9e3b6c77
#4 DONE 0.0s

#5 [internal] load build context
#5 transferring context: 83.38MB 0.5s done
#5 DONE 0.5s

#6 [2/4] RUN addgroup -S spring && adduser -S spring -G spring
#6 CACHED

#7 [3/4] WORKDIR /app
#7 CACHED

#8 [4/4] COPY build/libs/*.jar app.jar
#8 CACHED

#9 exporting to image
#9 exporting layers done
#9 writing image sha256:ee6e78a3e9f4dc9bfffb6d80fe458249d8d602fbe4f323e685d41e1b6308136f done
#9 naming to docker.io/parkitteam/analysis-service:build-109 done
#9 naming to docker.io/parkitteam/analysis-service:latest done
#9 DONE 0.0s
[Pipeline] }
[Pipeline] // dir
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Push Docker Image)
[Pipeline] tool
[Pipeline] envVarsForTool
[Pipeline] withEnv
[Pipeline] {
[Pipeline] echo
Pushing Docker Image to Docker Hub registry...
[Pipeline] withCredentials
Masking supported pattern matches of $DOCKER_PASSWORD
[Pipeline] {
[Pipeline] sh
+ echo ****
+ docker login -u parkitteam --password-stdin
WARNING! Your password will be stored unencrypted in /var/jenkins_home/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
[Pipeline] sh
+ docker push parkitteam/analysis-service:build-109
The push refers to repository [docker.io/parkitteam/analysis-service]
3a3d384c8e1a: Preparing
5d8acd136340: Preparing
5e5978dbc7e1: Preparing
0c6cb496c7ec: Preparing
29df493baa13: Preparing
0c6cb496c7ec: Waiting
29df493baa13: Waiting
5e5978dbc7e1: Waiting
5d8acd136340: Waiting
3a3d384c8e1a: Waiting
5e5978dbc7e1: Layer already exists
0c6cb496c7ec: Layer already exists
5d8acd136340: Layer already exists
3a3d384c8e1a: Layer already exists
29df493baa13: Layer already exists
build-109: digest: sha256:2b89a4319e4cd84234f6c1e30e8f4d52910575cf77becfcbf71929ef1076bfe2 size: 1366
[Pipeline] sh
+ docker push parkitteam/analysis-service:latest
The push refers to repository [docker.io/parkitteam/analysis-service]
3a3d384c8e1a: Preparing
5d8acd136340: Preparing
5e5978dbc7e1: Preparing
0c6cb496c7ec: Preparing
29df493baa13: Preparing
3a3d384c8e1a: Waiting
5d8acd136340: Waiting
5e5978dbc7e1: Waiting
0c6cb496c7ec: Waiting
29df493baa13: Waiting
29df493baa13: Layer already exists
0c6cb496c7ec: Layer already exists
5e5978dbc7e1: Layer already exists
5d8acd136340: Layer already exists
3a3d384c8e1a: Layer already exists
received unexpected HTTP status: 504 Gateway Time-out
[Pipeline] }
[Pipeline] // withCredentials
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Update K8s Manifests)
Stage "Update K8s Manifests" skipped due to earlier failure(s)
[Pipeline] getContext
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Cleanup)
Stage "Cleanup" skipped due to earlier failure(s)
[Pipeline] getContext
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Declarative: Post Actions)
[Pipeline] echo
Pipeline for analysis-service finished.
[Pipeline] echo
Build Failed.
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: script returned exit code 1
Finished: FAILURE
```

## ✨ 변경 내용
- Jenkins `Push Docker Image` 단계에 `retry(3)` 적용
  - `docker push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}`
  - `docker push ${DOCKER_IMAGE_NAME}:latest`
- Docker Hub 응답 지연(504 Gateway Time-out) 발생 시 자동 재시도하도록 수정

## ✅ 체크리스트
- [x] 빌드 및 테스트를 통과했나요?
- [x] 불필요한 로그나 주석은 제거했나요?

## 📝 리뷰 포인트
- 이번 변경은 Docker Hub push 실패 대응이 목적입니다.
- `latest` push에서 발생한 일시적 504 에러를 retry로 흡수하는 방향이 적절한지 봐주시면 됩니다.
- retry 횟수(`3`)가 과하지 않은지도 같이 확인 부탁드립니다.
