### PR TITLE
fix: argocd manifest push 재시도 적용

### DIFF
--- a/analysis-service/Jenkinsfile
+++ b/analysis-service/Jenkinsfile
@@ -86,31 +86,33 @@ pipeline {
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
                 withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh '''
-                        if [ ! -d "argocd-parkit/.git" ]; then
-                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
-                        fi
+                    retry(3) {
+                        sh '''
+                            if [ ! -d "argocd-parkit/.git" ]; then
+                                git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                            fi
 
-                        cd argocd-parkit
-                        git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
-                        git fetch origin main
-                        git checkout -B main origin/main
+                            cd argocd-parkit
+                            git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                            git fetch origin main
+                            git checkout -B main origin/main
 
-                        sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
-                            "${SERVICE_NAME}/deployment.yaml"
+                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                                "${SERVICE_NAME}/deployment.yaml"
 
-                        git config user.email "jenkins@ci.com"
-                        git config user.name "Jenkins CI"
-                        git add "${SERVICE_NAME}/deployment.yaml"
+                            git config user.email "jenkins@ci.com"
+                            git config user.name "Jenkins CI"
+                            git add "${SERVICE_NAME}/deployment.yaml"
 
-                        if git diff --cached --quiet; then
-                            echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                            exit 0
-                        fi
+                            if git diff --cached --quiet; then
+                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                                exit 0
+                            fi
 
-                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                        git push origin main
-                    '''
+                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                            git push origin main
+                        '''
+                    }
                 }
             }
         }

--- a/report-service/Jenkinsfile
+++ b/report-service/Jenkinsfile
@@ -86,31 +86,33 @@ pipeline {
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
                 withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh '''
-                        if [ ! -d "argocd-parkit/.git" ]; then
-                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
-                        fi
+                    retry(3) {
+                        sh '''
+                            if [ ! -d "argocd-parkit/.git" ]; then
+                                git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                            fi
 
-                        cd argocd-parkit
-                        git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
-                        git fetch origin main
-                        git checkout -B main origin/main
+                            cd argocd-parkit
+                            git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                            git fetch origin main
+                            git checkout -B main origin/main
 
-                        sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
-                            "${SERVICE_NAME}/deployment.yaml"
+                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                                "${SERVICE_NAME}/deployment.yaml"
 
-                        git config user.email "jenkins@ci.com"
-                        git config user.name "Jenkins CI"
-                        git add "${SERVICE_NAME}/deployment.yaml"
+                            git config user.email "jenkins@ci.com"
+                            git config user.name "Jenkins CI"
+                            git add "${SERVICE_NAME}/deployment.yaml"
 
-                        if git diff --cached --quiet; then
-                            echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                            exit 0
-                        fi
+                            if git diff --cached --quiet; then
+                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                                exit 0
+                            fi
 
-                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                        git push origin main
-                    '''
+                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                            git push origin main
+                        '''
+                    }
                 }
             }
         }

--- a/socket-service/Jenkinsfile
+++ b/socket-service/Jenkinsfile
@@ -85,31 +85,33 @@ pipeline {
             steps {
                 echo 'Updating image tag in argocd-parkit repository...'
                 withCredentials([usernamePassword(credentialsId: 'github-credentials', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh '''
-                        if [ ! -d "argocd-parkit/.git" ]; then
-                            git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
-                        fi
+                    retry(3) {
+                        sh '''
+                            if [ ! -d "argocd-parkit/.git" ]; then
+                                git clone "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                            fi
 
-                        cd argocd-parkit
-                        git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
-                        git fetch origin main
-                        git checkout -B main origin/main
+                            cd argocd-parkit
+                            git remote set-url origin "https://$GIT_USERNAME:$GIT_PASSWORD@github.com/Parkit-Team/argocd-parkit.git"
+                            git fetch origin main
+                            git checkout -B main origin/main
 
-                        sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
-                            "${SERVICE_NAME}/deployment.yaml"
+                            sed -i "s|image: ${DOCKER_IMAGE_NAME}:.*|image: ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}|g" \
+                                "${SERVICE_NAME}/deployment.yaml"
 
-                        git config user.email "jenkins@ci.com"
-                        git config user.name "Jenkins CI"
-                        git add "${SERVICE_NAME}/deployment.yaml"
+                            git config user.email "jenkins@ci.com"
+                            git config user.name "Jenkins CI"
+                            git add "${SERVICE_NAME}/deployment.yaml"
 
-                        if git diff --cached --quiet; then
-                            echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
-                            exit 0
-                        fi
+                            if git diff --cached --quiet; then
+                                echo "Manifest already points to ${DOCKER_IMAGE_NAME}:${DOCKER_TAG}"
+                                exit 0
+                            fi
 
-                        git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
-                        git push origin main
-                    '''
+                            git commit -m "[CI] Update ${SERVICE_NAME} image to ${DOCKER_TAG}"
+                            git push origin main
+                        '''
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves None

## ✨ 변경 내용
- `Update K8s Manifests` 단계에 `retry(3)` 적용
- `argocd-parkit` 저장소 push가 `fetch` 이후 다른 변경으로 밀렸을 때 최신 `origin/main` 기준으로 재시도하도록 수정
- 매번 전체 clone하지 않고 기존 `argocd-parkit` 작업 디렉터리가 있으면 재사용하도록 정리
- `git remote set-url origin ...`, `git fetch origin main`, `git checkout -B main origin/main` 흐름으로 최신 상태를 다시 맞춘 뒤 manifest 변경 재적용

## ✅ 체크리스트
- [x] 빌드 및 테스트를 통과했나요?
- [x] 불필요한 로그나 주석은 제거했나요?

## 📝 리뷰 포인트
- 문제의 직접 원인은 `argocd-parkit`의 `main`이 `fetch` 이후 `push` 전에 바뀌면서 `git push origin main`이 거절되는 상황입니다.
- 원격 브랜치가 먼저 갱신되는 경쟁 상황을 `retry(3)`로 흡수하는 데 초점을 맞췄습니다.
- 재시도마다 최신 `origin/main`을 다시 기준으로 삼도록 구현한 방식이 적절한지 확인 부탁드립니다.
