### PR TITLE
feat: add load testing assets and latency instrumentation

### DIFF
--- a/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/dto/CoachingSocketDto.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/dto/CoachingSocketDto.kt
@@ -13,6 +13,8 @@ data class ObstacleDistancesDto(
 data class CoachingSocketDto(
     val step: Int,
     val timestamp: String,
+    val analysisReceivedAtEpochMs: Long,
+    val analysisEmittedAtEpochMs: Long,
     // units: angle=deg, distance=m
     val targetAngle: Int,
     val targetDistance: Double,

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/service/RiskDetectionService.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/coaching/service/RiskDetectionService.kt
@@ -21,11 +21,23 @@ class RiskDetectionService(
     /**
      * 주행 이벤트를 기반으로 코칭 이벤트를 계산합니다.
      */
-	fun calculate(step: Int, event: ParkingSensorDto, initialX: Double? = null, initialY: Double? = null): CoachingSocketDto {
-		return createCoachingEvent(step, event, initialX, initialY)
+	fun calculate(
+		step: Int,
+		event: ParkingSensorDto,
+		initialX: Double? = null,
+		initialY: Double? = null,
+		analysisReceivedAtEpochMs: Long = System.currentTimeMillis(),
+	): CoachingSocketDto {
+		return createCoachingEvent(step, event, initialX, initialY, analysisReceivedAtEpochMs)
     }
 
-	private fun createCoachingEvent(step: Int, event: ParkingSensorDto, initialX: Double?, initialY: Double?): CoachingSocketDto {
+	private fun createCoachingEvent(
+		step: Int,
+		event: ParkingSensorDto,
+		initialX: Double?,
+		initialY: Double?,
+		analysisReceivedAtEpochMs: Long,
+	): CoachingSocketDto {
 		val targetAngleDeg = ParkingReference.coachingTargetAngleDeg(step)
 		val targetDistanceM = ParkingReference.coachingTargetMoveDistanceM(step, initialX)
 		
@@ -53,9 +65,13 @@ class RiskDetectionService(
 			else -> 5
 		}
 
+		val analysisEmittedAtEpochMs = System.currentTimeMillis()
+
 		return CoachingSocketDto(
             step = step,
             timestamp = java.time.LocalDateTime.now().toString(),
+			analysisReceivedAtEpochMs = analysisReceivedAtEpochMs,
+			analysisEmittedAtEpochMs = analysisEmittedAtEpochMs,
 			targetAngle = targetAngleDeg,
 			targetDistance = (targetDistanceM * 10).roundToInt() / 10.0,
 			currentAngle = event.handleAngle.roundToInt(),

--- a/analysis-service/src/main/kotlin/com/parkit/analysis/kafka/KafkaAnalysisConsumer.kt
+++ b/analysis-service/src/main/kotlin/com/parkit/analysis/kafka/KafkaAnalysisConsumer.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.parkit.analysis.coaching.service.RiskDetectionService
 import com.parkit.analysis.kafka.dto.ParkingSensorDto
-import com.parkit.analysis.kafka.mapper.toParkingEvent
+import com.parkit.analysis.parking.domain.ParkingEvent
 import com.parkit.analysis.parking.service.ParkingScoringService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
@@ -31,17 +31,37 @@ class KafkaAnalysisConsumer(
 	fun consume(record: ConsumerRecord<String, String>) {
 		val sessionId = record.key() ?: "unknown-session"
 		val message = record.value()
+		val analysisReceivedAtEpochMs = System.currentTimeMillis()
 		
 		try {
 			log.debug("Received Kafka message for session {}: {}", sessionId, message)
 			val sensorDto = objectMapper.readValue(message, ParkingSensorDto::class.java)
-			val parkingEvent = sensorDto.toParkingEvent()
+			val parkingEvent = ParkingEvent(
+				time = sensorDto.time,
+				x = sensorDto.x,
+				y = sensorDto.y,
+				z = sensorDto.z,
+				handleAngle = sensorDto.handleAngle,
+				sensor = ParkingEvent.SensorData(
+					frontDistance = sensorDto.frontDist,
+					leftDistance = sensorDto.leftDist,
+					rightDistance = sensorDto.rightDist,
+					rearDistance = sensorDto.rearDist,
+					speed = sensorDto.speed,
+				),
+			)
 
 			// 세션별 순차 처리를 위해 동기 방식으로 처리
 			val result = parkingScoringService.processParkingEvent(sessionId, parkingEvent).block()
 			
 			if (result != null) {
-				val coaching = riskDetectionService.calculate(result.step, sensorDto, result.initialX, result.initialY)
+				val coaching = riskDetectionService.calculate(
+					result.step,
+					sensorDto,
+					result.initialX,
+					result.initialY,
+					analysisReceivedAtEpochMs,
+				)
 				val coachingJson = objectMapper.writeValueAsString(coaching)
 				
 				// Kafka 전송도 완료될 때까지 대기

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,142 @@
+# Performance Test Guide
+
+이 디렉터리는 `parkit-server`의 세 서비스에 맞춘 부하테스트 자산을 모아둔 곳입니다.
+
+테스트 대상
+- `report-service`: HTTP API 지연시간과 에러율
+- `socket-service`: STOMP/WebSocket 브로드캐스트 지연시간
+- `analysis-service`: Kafka 입력부터 `socket-service` 브로드캐스트까지의 E2E 흐름
+
+사전 조건
+- `k6` 설치
+- `kcat` 설치 (`analysis-service` E2E용)
+- 대상 서비스 기동
+- `analysis-service`와 `socket-service` E2E 측정 시 Kafka와 Redis도 함께 기동
+
+권장 SLO 예시
+- `report-service`: `p95 http_req_duration < 500ms`, `error rate < 1%`
+- `socket-service`: `p95 socket_ws_delivery_latency_ms < 500ms`
+- `analysis-service` + `socket-service`: `p95 analysis_processing_latency_ms < 200ms`, `p95 socket_ws_delivery_latency_ms < 500ms`
+
+## Report Service
+
+대상 엔드포인트
+- `POST /api/driving-sessions/start`
+- `POST /api/driving-sessions/{sessionId}/sensor-logs`
+- `GET /api/driving-sessions/{sessionId}/report`
+- `POST /api/driving-sessions/{sessionId}/stop`
+
+실행 예시
+
+```bash
+k6 run \
+  -e REPORT_BASE_URL=http://localhost:8083 \
+  -e SENSOR_LOGS_PER_ITERATION=50 \
+  -e STAGE_1_TARGET=20 \
+  -e STAGE_2_TARGET=100 \
+  perf/report-service/driving-session-load.js
+```
+
+측정 포인트
+- `http_req_duration`
+- `report_sensor_log_duration`
+- `report_fetch_duration`
+- `http_req_failed`
+
+주의
+- 현재 구현은 전역적으로 가장 최근 `RUNNING` 세션을 재사용합니다.
+- 따라서 `start` 자체의 동시성 성능보다, 센서 로그 적재와 조회 부하를 보는 용도로 해석하는 것이 맞습니다.
+
+## Socket Service
+
+대상
+- SockJS websocket endpoint: `/ws/parkit/websocket`
+- STOMP subscribe destination: `/topic/coaching`
+
+실행 예시
+
+```bash
+k6 run \
+  -e SOCKET_WS_URL=ws://localhost:8082/ws/parkit/websocket \
+  -e STAGE_1_TARGET=50 \
+  -e STAGE_2_TARGET=300 \
+  -e TEST_DURATION_MS=120000 \
+  perf/socket-service/stomp-broadcast-load.js
+```
+
+측정 포인트
+- `analysis_processing_latency_ms`
+- `socket_broker_latency_ms`
+- `socket_ws_delivery_latency_ms`
+- `socket_valid_messages`
+
+해석
+- `analysis_processing_latency_ms`: `analysis-service`가 Kafka 레코드를 읽고 코칭 이벤트를 만든 시간
+- `socket_broker_latency_ms`: `analysis-service`가 Kafka에 보낸 뒤 `socket-service`가 브로드캐스트 직전까지 걸린 시간
+- `socket_ws_delivery_latency_ms`: `socket-service` 브로드캐스트 후 k6 클라이언트가 메시지를 받은 시간
+
+## Analysis Service E2E
+
+대상
+- Kafka topic `sensor-topic`
+- `analysis-service` consumer
+- `socket-service` websocket broadcast
+
+실행 순서
+1. `analysis-service`, `socket-service`, Kafka, Redis를 기동합니다.
+2. WebSocket 구독 부하를 시작합니다.
+3. Kafka에 센서 이벤트를 발행합니다.
+4. `k6` 결과에서 `analysis_processing_latency_ms`, `socket_ws_delivery_latency_ms`를 확인합니다.
+
+원샷 실행 예시
+
+```bash
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+SOCKET_WS_URL=ws://localhost:8082/ws/parkit/websocket \
+SESSION_COUNT=100 \
+REPEAT_COUNT=10 \
+STAGE_1_TARGET=50 \
+STAGE_2_TARGET=200 \
+perf/analysis-service/run-e2e-latency.sh
+```
+
+센서 이벤트만 별도 발행하고 싶다면:
+
+```bash
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
+SESSION_COUNT=100 \
+REPEAT_COUNT=10 \
+EVENT_INTERVAL_MS=20 \
+perf/analysis-service/publish-sensor-topic.sh
+```
+
+산출물
+- `perf/results/analysis-socket-summary.json`
+- `perf/results/analysis-socket-k6.log`
+
+## Kubernetes / ArgoCD 환경 권장 방식
+
+운영 유사 환경에서는 다음 순서가 가장 안정적입니다.
+
+1. ArgoCD로 스테이징 환경에 서비스 배포
+2. Kafka, Redis, Mongo 상태를 동일하게 준비
+3. `k6`는 별도 runner Pod 또는 외부 runner에서 실행
+4. 결과는 `k6 summary + Prometheus + Grafana`로 같이 확인
+
+운영 체크 항목
+- CPU / memory usage
+- Kafka consumer lag
+- Redis command latency
+- Mongo write latency
+- WebSocket 연결 유지율
+
+## 결과 보고 형식
+
+부하테스트 결과는 아래 형식으로 남기면 됩니다.
+
+```text
+대상: socket-service
+시나리오: 동시 300 구독자, 100 세션 x 10회 sensor-topic 발행
+결과: p95 analysis_processing_latency_ms=120ms, p95 socket_ws_delivery_latency_ms=210ms, error rate=0%
+판정: 목표(500ms 이하) 충족
+```

--- a/perf/analysis-service/KafkaSensorProducer.java
+++ b/perf/analysis-service/KafkaSensorProducer.java
@@ -1,0 +1,98 @@
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Properties;
+
+public class KafkaSensorProducer {
+	public static void main(String[] args) throws Exception {
+		String bootstrapServers = env("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092");
+		String topic = env("KAFKA_TOPIC", "sensor-topic");
+		Path csvPath = Path.of(env("CSV_PATH", "analysis-service/src/test/resources/data/step01.csv"));
+		int sessionCount = Integer.parseInt(env("SESSION_COUNT", "50"));
+		int repeatCount = Integer.parseInt(env("REPEAT_COUNT", "5"));
+		long eventIntervalMs = Long.parseLong(env("EVENT_INTERVAL_MS", "0"));
+		String sessionPrefix = env("SESSION_PREFIX", "load-session");
+
+		Properties props = new Properties();
+		props.put("bootstrap.servers", bootstrapServers);
+		props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+		props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+		props.put("acks", "all");
+		props.put("linger.ms", "0");
+
+		try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
+			for (int repeat = 1; repeat <= repeatCount; repeat++) {
+				for (int session = 1; session <= sessionCount; session++) {
+					String sessionId = sessionPrefix + "-" + repeat + "-" + session;
+					publishCsv(csvPath, topic, sessionId, producer, eventIntervalMs);
+				}
+			}
+			producer.flush();
+		}
+
+		System.out.printf(
+			"Published sensor events to %s on %s with %d sessions x %d repeats%n",
+			topic,
+			bootstrapServers,
+			sessionCount,
+			repeatCount
+		);
+	}
+
+	private static void publishCsv(
+		Path csvPath,
+		String topic,
+		String sessionId,
+		KafkaProducer<String, String> producer,
+		long eventIntervalMs
+	) throws IOException, InterruptedException {
+		try (BufferedReader reader = Files.newBufferedReader(csvPath)) {
+			String line;
+			boolean header = true;
+			while ((line = reader.readLine()) != null) {
+				if (header) {
+					header = false;
+					continue;
+				}
+
+				String[] tokens = line.split(",");
+				if (tokens.length < 12) {
+					continue;
+				}
+
+				String payload = String.format(
+					"{\"time\":%s,\"x\":%s,\"y\":%s,\"z\":%s,\"steer\":%s,\"wheel_degree\":%s,\"handle_angle\":%s,\"speed\":%s,\"front_dist\":%s,\"left_dist\":%s,\"right_dist\":%s,\"rear_dist\":%s}",
+					tokens[0].trim(),
+					tokens[1].trim(),
+					tokens[2].trim(),
+					tokens[3].trim(),
+					tokens[4].trim(),
+					tokens[5].trim(),
+					tokens[6].trim(),
+					tokens[7].trim(),
+					tokens[8].trim(),
+					tokens[9].trim(),
+					tokens[10].trim(),
+					tokens[11].trim()
+				);
+
+				producer.send(new ProducerRecord<>(topic, sessionId, payload)).get();
+				if (eventIntervalMs > 0) {
+					Thread.sleep(eventIntervalMs);
+				}
+			}
+		} catch (Exception e) {
+			throw new IOException("Failed to publish CSV for session " + sessionId, e);
+		}
+	}
+
+	private static String env(String key, String defaultValue) {
+		String value = System.getenv(key);
+		return value == null || value.isBlank() ? defaultValue : value;
+	}
+}

--- a/perf/analysis-service/publish-sensor-topic.sh
+++ b/perf/analysis-service/publish-sensor-topic.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}"
+KAFKA_TOPIC="${KAFKA_TOPIC:-sensor-topic}"
+CSV_PATH="${CSV_PATH:-analysis-service/src/test/resources/data/step01.csv}"
+SESSION_COUNT="${SESSION_COUNT:-50}"
+REPEAT_COUNT="${REPEAT_COUNT:-5}"
+EVENT_INTERVAL_MS="${EVENT_INTERVAL_MS:-0}"
+SESSION_PREFIX="${SESSION_PREFIX:-load-session}"
+
+if ! command -v kcat >/dev/null 2>&1; then
+	echo "kcat is required but was not found in PATH." >&2
+	exit 1
+fi
+
+if [[ ! -f "${CSV_PATH}" ]]; then
+	echo "CSV_PATH does not exist: ${CSV_PATH}" >&2
+	exit 1
+fi
+
+sleep_seconds() {
+	awk "BEGIN { printf \"%.3f\", ${EVENT_INTERVAL_MS} / 1000 }"
+}
+
+publish_event() {
+	local session_id="$1"
+	local time="$2"
+	local x="$3"
+	local y="$4"
+	local z="$5"
+	local steer="$6"
+	local wheel_degree="$7"
+	local handle_angle="$8"
+	local speed="$9"
+	local front_dist="${10}"
+	local left_dist="${11}"
+	local right_dist="${12}"
+	local rear_dist="${13}"
+
+	local payload
+	printf -v payload '{"time":%s,"x":%s,"y":%s,"z":%s,"steer":%s,"wheel_degree":%s,"handle_angle":%s,"speed":%s,"front_dist":%s,"left_dist":%s,"right_dist":%s,"rear_dist":%s}' \
+		"${time}" "${x}" "${y}" "${z}" "${steer}" "${wheel_degree}" "${handle_angle}" "${speed}" \
+		"${front_dist}" "${left_dist}" "${right_dist}" "${rear_dist}"
+
+	printf '%s:%s\n' "${session_id}" "${payload}"
+}
+
+for repeat in $(seq 1 "${REPEAT_COUNT}"); do
+	for session in $(seq 1 "${SESSION_COUNT}"); do
+		session_id="${SESSION_PREFIX}-${repeat}-${session}"
+		while IFS=, read -r time x y z steer wheel_degree handle_angle speed front_dist left_dist right_dist rear_dist; do
+			if [[ "${time}" == "time" ]]; then
+				continue
+			fi
+
+			publish_event \
+				"${session_id}" "${time}" "${x}" "${y}" "${z}" "${steer}" "${wheel_degree}" \
+				"${handle_angle}" "${speed}" "${front_dist}" "${left_dist}" "${right_dist}" "${rear_dist}"
+
+			if [[ "${EVENT_INTERVAL_MS}" != "0" ]]; then
+				sleep "$(sleep_seconds)"
+			fi
+		done < "${CSV_PATH}"
+	done
+done | kcat -P -b "${KAFKA_BOOTSTRAP_SERVERS}" -t "${KAFKA_TOPIC}" -K:
+
+echo "Published sensor events to ${KAFKA_TOPIC} on ${KAFKA_BOOTSTRAP_SERVERS}"

--- a/perf/analysis-service/run-e2e-latency.sh
+++ b/perf/analysis-service/run-e2e-latency.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+K6_BIN="${K6_BIN:-k6}"
+K6_SCRIPT="${K6_SCRIPT:-${ROOT_DIR}/perf/socket-service/stomp-broadcast-load.js}"
+SUMMARY_EXPORT="${SUMMARY_EXPORT:-${ROOT_DIR}/perf/results/analysis-socket-summary.json}"
+K6_STDOUT_LOG="${K6_STDOUT_LOG:-${ROOT_DIR}/perf/results/analysis-socket-k6.log}"
+PUBLISH_SCRIPT="${PUBLISH_SCRIPT:-${ROOT_DIR}/perf/analysis-service/publish-sensor-topic.sh}"
+
+mkdir -p "${ROOT_DIR}/perf/results"
+
+"${K6_BIN}" run --summary-export "${SUMMARY_EXPORT}" "${K6_SCRIPT}" > "${K6_STDOUT_LOG}" 2>&1 &
+K6_PID=$!
+
+cleanup() {
+	if kill -0 "${K6_PID}" >/dev/null 2>&1; then
+		kill "${K6_PID}" >/dev/null 2>&1 || true
+	fi
+}
+
+trap cleanup EXIT
+
+sleep "${K6_WARMUP_SECONDS:-5}"
+"${PUBLISH_SCRIPT}"
+
+wait "${K6_PID}"
+trap - EXIT
+
+echo "k6 summary written to ${SUMMARY_EXPORT}"
+echo "k6 log written to ${K6_STDOUT_LOG}"

--- a/perf/report-service/driving-session-load.js
+++ b/perf/report-service/driving-session-load.js
@@ -1,0 +1,114 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+const baseUrl = __ENV.REPORT_BASE_URL || 'http://localhost:8083';
+const sensorLogsPerIteration = Number(__ENV.SENSOR_LOGS_PER_ITERATION || 20);
+const sensorLogPauseMs = Number(__ENV.SENSOR_LOG_PAUSE_MS || 0);
+const reportLimit = Number(__ENV.REPORT_LIMIT || 2000);
+
+const sensorLogDuration = new Trend('report_sensor_log_duration', true);
+const startDuration = new Trend('report_start_duration', true);
+const stopDuration = new Trend('report_stop_duration', true);
+const reportDuration = new Trend('report_fetch_duration', true);
+const sensorLogFailures = new Counter('report_sensor_log_failures');
+
+export const options = {
+	scenarios: {
+		driving_session_http: {
+			executor: 'ramping-vus',
+			startVUs: 0,
+			stages: [
+				{ duration: __ENV.STAGE_1_DURATION || '30s', target: Number(__ENV.STAGE_1_TARGET || 10) },
+				{ duration: __ENV.STAGE_2_DURATION || '1m', target: Number(__ENV.STAGE_2_TARGET || 50) },
+				{ duration: __ENV.STAGE_3_DURATION || '30s', target: 0 },
+			],
+			gracefulRampDown: '10s',
+		},
+	},
+	thresholds: {
+		http_req_failed: ['rate<0.01'],
+		http_req_duration: ['p(95)<500'],
+		report_sensor_log_duration: ['p(95)<400'],
+		report_fetch_duration: ['p(95)<700'],
+	},
+};
+
+function jsonParams(tags) {
+	return {
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		tags,
+	};
+}
+
+function buildSensorPayload(sequence) {
+	return JSON.stringify({
+		time: sequence * 0.1,
+		x: 12.0 + sequence * 0.05,
+		y: -2.0 + sequence * 0.01,
+		z: 0.0,
+		steer: 0.0,
+		wheel_degree: 0.0,
+		handle_angle: (sequence % 10) * 3,
+		speed: 1.5,
+		front_dist: 2.4,
+		left_dist: 1.2,
+		right_dist: 1.3,
+		rear_dist: 2.1,
+	});
+}
+
+export default function () {
+	const userId = `load-user-${__VU}-${__ITER}`;
+	const startResponse = http.post(
+		`${baseUrl}/api/driving-sessions/start`,
+		JSON.stringify({ userId }),
+		jsonParams({ endpoint: 'start-session' }),
+	);
+	startDuration.add(startResponse.timings.duration);
+	check(startResponse, {
+		'start session returns 201': (res) => res.status === 201,
+	});
+
+	const sessionId = startResponse.json('sessionId');
+
+	for (let i = 0; i < sensorLogsPerIteration; i += 1) {
+		const sensorResponse = http.post(
+			`${baseUrl}/api/driving-sessions/${sessionId}/sensor-logs`,
+			buildSensorPayload(i),
+			jsonParams({ endpoint: 'sensor-log' }),
+		);
+		sensorLogDuration.add(sensorResponse.timings.duration);
+		const ok = check(sensorResponse, {
+			'sensor log returns 201': (res) => res.status === 201,
+		});
+		if (!ok) {
+			sensorLogFailures.add(1);
+		}
+
+		if (sensorLogPauseMs > 0) {
+			sleep(sensorLogPauseMs / 1000);
+		}
+	}
+
+	const reportResponse = http.get(
+		`${baseUrl}/api/driving-sessions/${sessionId}/report?limit=${reportLimit}`,
+		{ tags: { endpoint: 'session-report' } },
+	);
+	reportDuration.add(reportResponse.timings.duration);
+	check(reportResponse, {
+		'report returns 200': (res) => res.status === 200,
+	});
+
+	const stopResponse = http.post(
+		`${baseUrl}/api/driving-sessions/${sessionId}/stop`,
+		JSON.stringify({ frontendScore: 87.5 }),
+		jsonParams({ endpoint: 'stop-session' }),
+	);
+	stopDuration.add(stopResponse.timings.duration);
+	check(stopResponse, {
+		'stop session returns 200': (res) => res.status === 200,
+	});
+}

--- a/perf/socket-service/StompLoadClient.java
+++ b/perf/socket-service/StompLoadClient.java
@@ -1,0 +1,147 @@
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StompLoadClient {
+	public static void main(String[] args) throws Exception {
+		String endpoint = env("STOMP_ENDPOINT", "ws://127.0.0.1:8082/ws/parkit");
+		String destination = env("STOMP_DESTINATION", "/topic/coaching-mock");
+		int clientCount = Integer.parseInt(env("CLIENT_COUNT", "100"));
+		int durationSeconds = Integer.parseInt(env("DURATION_SECONDS", "30"));
+		int connectTimeoutSeconds = Integer.parseInt(env("CONNECT_TIMEOUT_SECONDS", "30"));
+
+		List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+		SockJsClient sockJsClient = new SockJsClient(transports);
+		WebSocketStompClient stompClient = new WebSocketStompClient(sockJsClient);
+		stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+		List<StompSession> sessions = new ArrayList<>();
+		List<Long> latencies = new CopyOnWriteArrayList<>();
+		AtomicInteger messageCount = new AtomicInteger();
+		AtomicInteger connectFailures = new AtomicInteger();
+		CountDownLatch connected = new CountDownLatch(clientCount);
+		List<CompletableFuture<StompSession>> futures = new ArrayList<>();
+
+		for (int i = 0; i < clientCount; i++) {
+			int clientIndex = i;
+			CompletableFuture<StompSession> future = stompClient.connectAsync(endpoint, new StompSessionHandlerAdapter() {
+				@Override
+				public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+					session.subscribe(destination, new StompSessionHandlerAdapter() {
+						@Override
+						public Type getPayloadType(StompHeaders headers) {
+							return Map.class;
+						}
+
+						@Override
+						public void handleFrame(StompHeaders headers, Object payload) {
+							if (!(payload instanceof Map<?, ?> body)) {
+								return;
+							}
+
+							Long forwardedAt = readLong(body, "socketForwardedAtEpochMs");
+							Long emittedAt = readLong(body, "analysisEmittedAtEpochMs");
+							long basis = forwardedAt != null ? forwardedAt : emittedAt != null ? emittedAt : System.currentTimeMillis();
+							long latency = System.currentTimeMillis() - basis;
+							latencies.add(latency);
+							messageCount.incrementAndGet();
+						}
+					});
+					connected.countDown();
+				}
+
+				@Override
+				public void handleTransportError(StompSession session, Throwable exception) {
+					connectFailures.incrementAndGet();
+					connected.countDown();
+				}
+
+				@Override
+				public void handleFrame(StompHeaders headers, Object payload) {
+					// no-op
+				}
+			});
+			futures.add(future.exceptionally(ex -> {
+				System.err.printf("client-%d failed to connect: %s%n", clientIndex, ex.getMessage());
+				connectFailures.incrementAndGet();
+				connected.countDown();
+				return null;
+			}));
+		}
+
+		connected.await(connectTimeoutSeconds, TimeUnit.SECONDS);
+		for (CompletableFuture<StompSession> future : futures) {
+			StompSession session = future.getNow(null);
+			if (session != null && session.isConnected()) {
+				sessions.add(session);
+			}
+		}
+
+		Thread.sleep(durationSeconds * 1000L);
+
+		for (StompSession session : sessions) {
+			try {
+				session.disconnect();
+			} catch (Exception ignored) {
+			}
+		}
+		stompClient.stop();
+
+		List<Long> sorted = new ArrayList<>(latencies);
+		Collections.sort(sorted);
+
+		System.out.printf("clients=%d connected=%d failures=%d messages=%d%n",
+			clientCount, sessions.size(), connectFailures.get(), messageCount.get());
+		if (sorted.isEmpty()) {
+			System.out.println("No messages received.");
+			return;
+		}
+
+		System.out.printf("avg_ms=%.2f p50_ms=%d p95_ms=%d p99_ms=%d max_ms=%d%n",
+			sorted.stream().mapToLong(Long::longValue).average().orElse(0),
+			percentile(sorted, 0.50),
+			percentile(sorted, 0.95),
+			percentile(sorted, 0.99),
+			sorted.get(sorted.size() - 1));
+	}
+
+	private static long percentile(List<Long> values, double ratio) {
+		int index = (int) Math.ceil(values.size() * ratio) - 1;
+		index = Math.min(Math.max(index, 0), values.size() - 1);
+		return values.get(index);
+	}
+
+	private static Long readLong(Map<?, ?> body, String key) {
+		Object value = body.get(key);
+		if (value instanceof Number number) {
+			return number.longValue();
+		}
+		if (value instanceof String stringValue && !stringValue.isBlank()) {
+			return Long.parseLong(stringValue);
+		}
+		return null;
+	}
+
+	private static String env(String key, String defaultValue) {
+		String value = System.getenv(key);
+		return value == null || value.isBlank() ? defaultValue : value;
+	}
+}

--- a/perf/socket-service/stomp-broadcast-load.js
+++ b/perf/socket-service/stomp-broadcast-load.js
@@ -1,0 +1,140 @@
+import ws from 'k6/ws';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const wsBaseUrl = __ENV.SOCKET_WS_URL || 'ws://localhost:8082/ws/parkit/websocket';
+const subscribeDestination = __ENV.STOMP_SUBSCRIBE_DESTINATION || '/topic/coaching';
+const testDurationMs = Number(__ENV.TEST_DURATION_MS || 60000);
+
+const connectFailures = new Counter('socket_connect_failures');
+const stompFramesReceived = new Counter('socket_stomp_frames_received');
+const wsDeliveryLatency = new Trend('socket_ws_delivery_latency_ms', true);
+const socketBrokerLatency = new Trend('socket_broker_latency_ms', true);
+const analysisProcessingLatency = new Trend('analysis_processing_latency_ms', true);
+const validMessages = new Rate('socket_valid_messages');
+
+export const options = {
+	scenarios: {
+		stomp_clients: {
+			executor: 'ramping-vus',
+			startVUs: 0,
+			stages: [
+				{ duration: __ENV.STAGE_1_DURATION || '30s', target: Number(__ENV.STAGE_1_TARGET || 20) },
+				{ duration: __ENV.STAGE_2_DURATION || '1m', target: Number(__ENV.STAGE_2_TARGET || 100) },
+				{ duration: __ENV.STAGE_3_DURATION || '30s', target: 0 },
+			],
+			gracefulRampDown: '10s',
+			exec: 'subscribe',
+		},
+	},
+	thresholds: {
+		socket_connect_failures: ['count<1'],
+		socket_valid_messages: ['rate>0.99'],
+		socket_ws_delivery_latency_ms: ['p(95)<500'],
+	},
+};
+
+function stompFrame(command, headers = {}, body = '') {
+	const headerLines = Object.entries(headers)
+		.map(([key, value]) => `${key}:${value}`)
+		.join('\n');
+	return `${command}\n${headerLines}\n\n${body}\u0000`;
+}
+
+function parseStompFrames(buffer) {
+	return buffer
+		.split('\u0000')
+		.map((frame) => frame.trim())
+		.filter((frame) => frame.length > 0);
+}
+
+function parseMessageBody(frame) {
+	const divider = frame.indexOf('\n\n');
+	if (divider < 0) {
+		return null;
+	}
+
+	return frame.slice(divider + 2);
+}
+
+export function subscribe() {
+	const response = ws.connect(wsBaseUrl, {}, function (socket) {
+		let receivedConnectedFrame = false;
+
+		socket.on('open', function () {
+			socket.send(
+				stompFrame('CONNECT', {
+					'accept-version': '1.2,1.1,1.0',
+					'heart-beat': '0,0',
+				}),
+			);
+		});
+
+		socket.on('message', function (message) {
+			const frames = parseStompFrames(message);
+			for (const frame of frames) {
+				stompFramesReceived.add(1);
+				if (frame.startsWith('CONNECTED')) {
+					receivedConnectedFrame = true;
+					socket.send(
+						stompFrame('SUBSCRIBE', {
+							id: `sub-${__VU}`,
+							destination: subscribeDestination,
+							ack: 'auto',
+						}),
+					);
+					continue;
+				}
+
+				if (!frame.startsWith('MESSAGE')) {
+					continue;
+				}
+
+				const body = parseMessageBody(frame);
+				if (!body) {
+					validMessages.add(false);
+					continue;
+				}
+
+				const payload = JSON.parse(body);
+				const now = Date.now();
+				const analysisReceivedAt = Number(payload.analysisReceivedAtEpochMs);
+				const analysisEmittedAt = Number(payload.analysisEmittedAtEpochMs);
+				const socketForwardedAt = Number(payload.socketForwardedAtEpochMs);
+
+				if (
+					Number.isFinite(analysisReceivedAt) &&
+					Number.isFinite(analysisEmittedAt) &&
+					Number.isFinite(socketForwardedAt)
+				) {
+					analysisProcessingLatency.add(analysisEmittedAt - analysisReceivedAt);
+					socketBrokerLatency.add(socketForwardedAt - analysisEmittedAt);
+					wsDeliveryLatency.add(now - socketForwardedAt);
+					validMessages.add(true);
+				} else {
+					validMessages.add(false);
+				}
+			}
+		});
+
+		socket.on('error', function () {
+			connectFailures.add(1);
+		});
+
+		socket.setTimeout(function () {
+			socket.close();
+		}, testDurationMs);
+
+		socket.setInterval(function () {
+			if (receivedConnectedFrame) {
+				socket.send('\n');
+			}
+		}, 10000);
+	});
+
+	check(response, {
+		'websocket upgrade succeeded': (res) => res && res.status === 101,
+	});
+
+	sleep(1);
+}

--- a/socket-service/src/main/kotlin/com/parkit/socket/dto/CoachingSocketDto.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/dto/CoachingSocketDto.kt
@@ -23,6 +23,12 @@ data class CoachingSocketDto(
 	val step: Int,
 	@field:Schema(description = "타임스탬프 (RFC3333/ISO-8601)")
 	val timestamp: String,
+	@field:Schema(description = "analysis-service가 Kafka 레코드를 읽은 시각(epoch ms)")
+	val analysisReceivedAtEpochMs: Long,
+	@field:Schema(description = "analysis-service가 Kafka로 코칭 이벤트를 보낸 시각(epoch ms)")
+	val analysisEmittedAtEpochMs: Long,
+	@field:Schema(description = "socket-service가 WebSocket 브로드캐스트 직전 기록한 시각(epoch ms)")
+	val socketForwardedAtEpochMs: Long? = null,
     @field:Schema(description = "목표 각도(deg)")
     val targetAngle: Int,
     @field:Schema(description = "목표 이동 거리(m)")

--- a/socket-service/src/main/kotlin/com/parkit/socket/kafka/CoachingEventConsumer.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/kafka/CoachingEventConsumer.kt
@@ -26,7 +26,10 @@ class CoachingEventConsumer(
 	fun consume(message: String) {
 		try {
 			val event = objectMapper.readValue<CoachingSocketDto>(message)
-			messagingTemplate.convertAndSend(TOPIC_DESTINATION, event)
+			messagingTemplate.convertAndSend(
+				TOPIC_DESTINATION,
+				event.copy(socketForwardedAtEpochMs = System.currentTimeMillis()),
+			)
 		} catch (e: Exception) {
 			log.error("Failed to process coaching-event message", e)
 		}

--- a/socket-service/src/main/kotlin/com/parkit/socket/mock/CoachingScheduler.kt
+++ b/socket-service/src/main/kotlin/com/parkit/socket/mock/CoachingScheduler.kt
@@ -39,6 +39,9 @@ class CoachingScheduler(
 		val mockData = CoachingSocketDto(
 			step = 1,
 			timestamp = java.time.LocalDateTime.now().toString(),
+			analysisReceivedAtEpochMs = System.currentTimeMillis(),
+			analysisEmittedAtEpochMs = System.currentTimeMillis(),
+			socketForwardedAtEpochMs = System.currentTimeMillis(),
             targetAngle = 0,
             targetDistance = 1.0,
             currentAngle = 0,


### PR DESCRIPTION
## Summary
- add reusable load testing assets for report-service, socket-service, and analysis-service
- add websocket latency instrumentation fields for analysis-service and socket-service payloads
- add a Java STOMP load client and Kafka sensor event producer for on-prem performance measurement

## Verification
- k6 inspect perf/report-service/driving-session-load.js
- k6 inspect perf/socket-service/stomp-broadcast-load.js
- bash -n perf/analysis-service/publish-sensor-topic.sh
- bash -n perf/analysis-service/run-e2e-latency.sh
- GRADLE_USER_HOME=/tmp/gradle-analysis bash ./gradlew compileKotlin --console=plain (analysis-service)
- JAVA_HOME=/Users/yujin/Library/Java/JavaVirtualMachines/ms-17.0.16/Contents/Home GRADLE_USER_HOME=/tmp/gradle-socket bash ./gradlew compileKotlin --console=plain (socket-service)